### PR TITLE
Fix README run example and set workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN python -m playwright install chromium && \
 
 # ─── 4️⃣  Copy your functions code ───────────────────────────────────
 COPY . /home/site/wwwroot
+WORKDIR /home/site/wwwroot
 
 # ─── 5️⃣  ⚠️ Keep running as **root** in local dev so port-80 bind works
 #          In production you can switch back to www-data if you prefer.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The project is contributed to and maintained by the **[Dhisana AI](https://www.d
 docker build -t gtm-ai-tools .
 ```
 
-2. Run a utility inside the container. The example below runs `openai_sample.py` and loads environment variables from `.env`:
+2. Run a utility inside the container. The example below runs `openai_sample.py` and loads environment variables from `.env`. The image sets the working directory to `/home/site/wwwroot`, so scripts inside the `utils/` directory can be referenced relatively:
 
 ```bash
 docker run --env-file .env gtm-ai-tools python utils/openai_sample.py "Hello!"


### PR DESCRIPTION
## Summary
- set `WORKDIR /home/site/wwwroot` in the Dockerfile so container paths match the repo layout
- clarify README instructions that scripts under `utils/` can be run relative to the working directory

## Testing
- `python -m py_compile utils/openai_sample.py`

------
https://chatgpt.com/codex/tasks/task_e_683a168d80b4832d9a610e5f72fb5ea5