### PR TITLE
Use OpenAI Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The project is contributed to and maintained by the **[Dhisana AI](https://www.d
 docker build -t gtm-ai-tools .
 ```
 
-2. Run a utility inside the container. The example below runs `openai_sample.py` and loads environment variables from `.env`. The image sets the working directory to `/home/site/wwwroot`, so scripts inside the `utils/` directory can be referenced relatively:
+2. Run a utility inside the container. The example below runs `openai_sample.py` and loads environment variables from `.env`. The script demonstrates the **Responses API** and the image sets the working directory to `/home/site/wwwroot`, so scripts inside the `utils/` directory can be referenced relatively:
 
 ```bash
 docker run --env-file .env gtm-ai-tools python utils/openai_sample.py "Hello!"

--- a/utils/openai_sample.py
+++ b/utils/openai_sample.py
@@ -1,12 +1,17 @@
-"""Simple utility to call the OpenAI API with a prompt."""
+"""Simple utility demonstrating the OpenAI Responses API."""
 
-import os
+from __future__ import annotations
+
 import argparse
-import openai
+import os
+
+from openai import OpenAI
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Send a prompt to OpenAI and print the response")
+    parser = argparse.ArgumentParser(
+        description="Send a prompt to OpenAI and print the response"
+    )
     parser.add_argument("prompt", help="Prompt text to send")
     args = parser.parse_args()
 
@@ -14,10 +19,15 @@ def main() -> None:
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY environment variable is not set")
 
-    openai.api_key = api_key
-    response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": args.prompt}],
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[
+            {"role": "system", "content": "You are a concise, helpful assistant."},
+            {"role": "user", "content": args.prompt},
+        ],
+        text={"format": "markdown"},
+        store=False,
     )
     print(response.choices[0].message.content)
 


### PR DESCRIPTION
## Summary
- switch openai_sample to the new Responses API
- mention the Responses API in the README

## Testing
- `python -m py_compile utils/openai_sample.py`
- `python utils/openai_sample.py --help` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_683a1ca66eb8832da501a8a601d4dd32