### PR TITLE
Add Docker and API key docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ The project is contributed to and maintained by the **[Dhisana AI](https://www.d
 - `requirements.txt` – Python dependencies for the utilities.
 - `.env` – Environment variables consumed by the utilities.
 
+## Prerequisites
+
+- Ensure Docker is installed. See [Installing Docker](docs/install_docker.md).
+- Obtain API keys and add them to `.env`. See [API key setup](docs/api_keys.md).
+
+
 ## Running with Docker
 
 1. Build the Docker image:

--- a/docs/api_keys.md
+++ b/docs/api_keys.md
@@ -1,0 +1,33 @@
+# Obtaining API Keys
+
+This project uses several APIs. Follow the steps below to generate the required keys and add them to your environment variables.
+
+## OpenAI API Key
+
+1. Visit [https://platform.openai.com/signup](https://platform.openai.com/signup) and sign up or log in.
+2. Click your profile icon and choose **View API keys**.
+3. Click **Create new secret key** and copy the value displayed.
+
+## SERAPI API Key
+
+1. Go to [https://serpapi.com](https://serpapi.com) and create an account.
+2. After verifying your email, the dashboard displays your API key.
+3. Copy the key shown under **API key**.
+
+## Dhisana API Key
+
+1. Sign up at [https://www.dhisana.ai](https://www.dhisana.ai).
+2. Select **API Credentials** from the menu.
+3. Click **New API Key** and copy the value provided.
+
+## Adding the keys to the environment
+
+Edit the `.env` file in the project root and set each key:
+
+```bash
+OPENAI_API_KEY=your_openai_key
+SERAPI_API_KEY=your_serapi_key
+DHISANA_API_KEY=your_dhisana_key
+```
+
+Save the file. The utilities will read these variables when run.

--- a/docs/install_docker.md
+++ b/docs/install_docker.md
@@ -1,0 +1,22 @@
+# Installing Docker
+
+## On Windows using WSL
+
+1. Open **PowerShell** as Administrator and run `wsl --install` to enable WSL&nbsp;2.
+2. Install the **Ubuntu** distribution from the Microsoft Store and launch it once to finish setup.
+3. Download and install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/).
+4. In Docker Desktop settings enable **WSL integration** for your Ubuntu distribution.
+5. Open your Ubuntu terminal and verify the installation with:
+   ```bash
+   docker --version
+   ```
+
+## On Macbook
+
+1. Download [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/). Choose the Intel or Apple chip version that matches your hardware.
+2. Open the downloaded `.dmg` file and drag **Docker** to **Applications**.
+3. Launch Docker from **Applications** and grant the requested privileges.
+4. Verify the installation from **Terminal**:
+   ```bash
+   docker --version
+   ```


### PR DESCRIPTION
## Summary
- document how to install Docker for Windows (WSL) and Mac
- add instructions to obtain OpenAI, SERAPI and Dhisana API keys
- link the new documentation from the main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a21dfb914832db2668ea39d8c67f2