### PR TITLE
Add company info lookup utility

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -39,3 +39,14 @@ docker run --env-file .env -v $(pwd):/workspace gtm-ai-tools \
 ```
 
 This creates `results.csv` in your current directory containing a `user_linkedin_url` column that you can access directly on your host machine.
+## Find Company Info
+
+`find_company_info.py` looks up a company's website, primary domain and LinkedIn page using Google search. It uses the `SERAPI_API_KEY` environment variable for Google queries.
+
+Run it with the company name and optional location:
+
+```bash
+python utils/find_company_info.py "Dhisana" -l "San Francisco"
+```
+
+The script prints a JSON object containing `company_website`, `company_domain` and `linkedin_url`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ openai
 playwright==1.42.0
 playwright-stealth
 aiohttp
+
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add a `find_company_info.py` utility that finds a company's website, domain and LinkedIn page
- document the new utility in `docs/utils_usage.md`
- include `beautifulsoup4` dependency

## Testing
- `python -m py_compile utils/*.py`
- `python utils/find_company_info.py "OpenAI" -l "San Francisco" | head` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683a2a76c9e0832da6d1c89b54281161