### PR TITLE
Add Taskfile with basic commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,11 @@ RUN apt-get update && \
         libcups2 libxss1 libdrm2 libgbm1 \
         libgtk-3-0 libasound2 libx11-xcb1 \
         libxcb1 libxcomposite1 libxdamage1 libxrandr2 \
-        xdg-utils fonts-liberation && \
+    xdg-utils fonts-liberation && \
     rm -rf /var/lib/apt/lists/*
+
+# Install Taskfile runner for convenient local usage
+RUN curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 
 # ─── 2️⃣  Python deps (add setuptools!) ───────────────────────────────
 COPY requirements.txt /

--- a/README.md
+++ b/README.md
@@ -18,21 +18,38 @@ The project is contributed to and maintained by the **[Dhisana AI](https://www.d
 - Install Git and clone this repository. See [Git setup](docs/doc.md).
 
 
-## Running with Docker
+## Running the utilities
 
-1. Build the Docker image:
-
-```bash
-docker build -t gtm-ai-tools .
-```
-
-2. Run a utility inside the container. The example below runs `openai_sample.py` and loads environment variables from `.env`. The script demonstrates the **Responses API** and the image sets the working directory to `/home/site/wwwroot`, so scripts inside the `utils/` directory can be referenced relatively:
+This project ships with a `Taskfile.yml` for simplified commands. The
+[`task`](https://taskfile.dev) tool is installed inside the Docker image and can
+be installed locally using the official script:
 
 ```bash
-docker run --env-file .env gtm-ai-tools python utils/openai_sample.py "Hello!"
+curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
 ```
 
-This will print the response returned from the OpenAI API using the key provided in the `.env` file.
+Common actions:
+
+1. Build the Docker image
+
+   ```bash
+   task docker:build
+   ```
+
+2. Update the repository
+
+   ```bash
+   task git:pull
+   ```
+
+3. Run a utility inside the container
+
+   ```bash
+   task run:command -- python utils/openai_sample.py "Hello!"
+   ```
+
+   The output of the command is saved to `output/run.log` in your working
+   directory.
 
 ## Adding new utilities
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+vars:
+  IMAGE: gtm-ai-tools
+
+silent: false
+
+tasks:
+  git:pull:
+    cmds:
+      - git pull
+
+  docker:build:
+    cmds:
+      - docker build -t ${IMAGE} .
+
+  run:command:
+    desc: Run a command inside the Docker image and capture output
+    cmds:
+      - mkdir -p output
+      - |
+        docker run --env-file .env -v $(pwd)/output:/workspace ${IMAGE} ${CLI_ARGS} | tee output/run.log

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -12,10 +12,10 @@ Run it from the project root (or inside the container) with a prompt:
 python utils/openai_sample.py "Hello!"
 ```
 
-Or with Docker after building the image:
+Or using the Taskfile after building the image:
 
 ```bash
-docker run --env-file .env gtm-ai-tools python utils/openai_sample.py "Hello!"
+task run:command -- python utils/openai_sample.py "Hello!"
 ```
 
 The script prints the text from the `responses.create` call.
@@ -30,12 +30,11 @@ Example usage fetching 20 results:
 python utils/linkedin_search_to_csv.py "site:linkedin.com/in growth hacker" results.csv -n 20
 ```
 
-Or inside Docker with volume mount to access the output file locally:
+Or using the Taskfile with a mounted volume to access the output file locally:
 
 ```bash
-docker run --env-file .env -v $(pwd):/workspace gtm-ai-tools \
-    python utils/linkedin_search_to_csv.py \
-    "site:linkedin.com/in growth hacker" /workspace/results.csv -n 20
+task run:command -- python utils/linkedin_search_to_csv.py \
+    "site:linkedin.com/in growth hacker" results.csv -n 20
 ```
 
 This creates `results.csv` in your current directory containing a `user_linkedin_url` column that you can access directly on your host machine.
@@ -46,7 +45,7 @@ This creates `results.csv` in your current directory containing a `user_linkedin
 Run it with the company name and optional location:
 
 ```bash
-python utils/find_company_info.py "Dhisana" -l "San Francisco"
+task run:command -- python utils/find_company_info.py "Dhisana" -l "San Francisco"
 ```
 
 The script prints a JSON object containing `company_website`, `company_domain` and `linkedin_url`.


### PR DESCRIPTION
## Summary
- include new Taskfile for common commands
- install task utility in Dockerfile
- document using `task` to build and run utilities
- update usage docs to prefer `task`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683a2c93aef8832d9576d6f62e825926