### PR TITLE
Fix docker build task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,11 +12,11 @@ tasks:
 
   docker:build:
     cmds:
-      - docker build -t ${IMAGE} .
+      - docker build -t {{.IMAGE}} .
 
   run:command:
     desc: Run a command inside the Docker image and capture output
     cmds:
       - mkdir -p output
       - |
-        docker run --env-file .env -v $(pwd)/output:/workspace ${IMAGE} ${CLI_ARGS} | tee output/run.log
+        docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} ${CLI_ARGS} | tee output/run.log


### PR DESCRIPTION
## Summary
- reference Task variables properly in the `docker:build` and `run:command` tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683a2e49f400832d843ce9491a9f6161