### PR TITLE
Update docs for output directory mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,21 @@ Common actions:
 3. Run a utility inside the container
 
    ```bash
-   task run:command -- python utils/openai_sample.py "Hello!"
-   ```
+task run:command -- python utils/openai_sample.py "Hello!"
+```
 
    The output of the command is saved to `output/run.log` in your working
    directory.
+
+To keep files produced by a command, write them to `/workspace` inside the
+container. The `output/` directory on your host maps to this path. For example:
+
+```bash
+task run:command -- python utils/linkedin_search_to_csv.py \
+    "site:linkedin.com/in growth hacker" /workspace/results.csv -n 20
+```
+
+After the run you will find `results.csv` inside the `output/` directory.
 
 ## Adding new utilities
 

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -34,10 +34,11 @@ Or using the Taskfile with a mounted volume to access the output file locally:
 
 ```bash
 task run:command -- python utils/linkedin_search_to_csv.py \
-    "site:linkedin.com/in growth hacker" results.csv -n 20
+    "site:linkedin.com/in growth hacker" /workspace/results.csv -n 20
 ```
-
-This creates `results.csv` in your current directory containing a `user_linkedin_url` column that you can access directly on your host machine.
+The Taskfile mounts the `output/` directory from your host to `/workspace`
+inside the container. By writing to `/workspace/results.csv` you will find the
+file at `output/results.csv` locally. Inspect it with `cat output/results.csv`.
 ## Find Company Info
 
 `find_company_info.py` looks up a company's website, primary domain and LinkedIn page using Google search. It uses the `SERAPI_API_KEY` environment variable for Google queries.


### PR DESCRIPTION
## Summary
- clarify how to keep files from container runs via `/workspace`
- document output path when using Taskfile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a3269cdbc832d9fdde94d8d81c96e