### PR TITLE
Copy run outputs to /tmp/outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,5 +161,6 @@ cython_debug/
 .DS_Store
 .python-version
 
-
+# Local output directories from Taskfile runs
+output/
 logs/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ task run:command -- python utils/linkedin_search_to_csv.py \
 ```
 
 After the run you will find `results.csv` inside the `output/` directory.
+The Taskfile also copies any files created in `output/` to `/tmp/outputs`,
+creating that directory if it does not already exist. This provides a stable
+location for retrieving results outside the project tree.
 
 ## Adding new utilities
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,3 +21,5 @@ tasks:
       - |
         echo Running: docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} {{.CLI_ARGS}}
         docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} {{.CLI_ARGS}} 2>&1 | tee output/run.log
+      - mkdir -p /tmp/outputs
+      - cp -a output/* /tmp/outputs/ 2>/dev/null || true

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -39,6 +39,8 @@ task run:command -- python utils/linkedin_search_to_csv.py \
 The Taskfile mounts the `output/` directory from your host to `/workspace`
 inside the container. By writing to `/workspace/results.csv` you will find the
 file at `output/results.csv` locally. Inspect it with `cat output/results.csv`.
+After the command finishes, everything in `output/` is also copied to
+`/tmp/outputs` for convenience.
 ## Find Company Info
 
 `find_company_info.py` looks up a company's website, primary domain and LinkedIn page using Google search. It uses the `SERAPI_API_KEY` environment variable for Google queries.


### PR DESCRIPTION
## Summary
- copy output directory to `/tmp/outputs` after each container run
- document new output location in README and docs
- ignore local `output/` folder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a3410faa8832d9e75c6338cda2b79