### PR TITLE
Refactor utils and add basic tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import sys
+import pathlib
+import types
+
+# Make project root importable
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Provide simple stubs for external dependencies if they are missing
+if 'aiohttp' not in sys.modules:
+    aiohttp = types.ModuleType('aiohttp')
+    class DummySession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, *a, **kw):
+            class Resp:
+                async def json(self):
+                    return {}
+                def raise_for_status(self):
+                    pass
+            return Resp()
+        async def get(self, *a, **kw):
+            class Resp:
+                status = 200
+                async def text(self):
+                    return ""
+                async def __aenter__(self_inner):
+                    return self_inner
+                async def __aexit__(self_inner, exc_type, exc, tb):
+                    pass
+            return Resp()
+    aiohttp.ClientSession = DummySession
+    sys.modules['aiohttp'] = aiohttp
+
+if 'bs4' not in sys.modules:
+    bs4 = types.ModuleType('bs4')
+    class DummySoup:
+        def __init__(self, *a, **kw):
+            pass
+        def find_all(self, *a, **kw):
+            return []
+    bs4.BeautifulSoup = DummySoup
+    sys.modules['bs4'] = bs4
+
+if 'openai' not in sys.modules:
+    openai = types.ModuleType('openai')
+    class DummyClient:
+        def __init__(self, api_key=None):
+            self.responses = types.SimpleNamespace(create=lambda **kw: types.SimpleNamespace(output_text="dummy"))
+    openai.OpenAI = DummyClient
+    sys.modules['openai'] = openai
+
+import pytest

--- a/tests/test_find_a_user.py
+++ b/tests/test_find_a_user.py
@@ -1,0 +1,11 @@
+import asyncio
+from utils import find_a_user_by_name_and_keywords as mod
+
+async def fake_search(*args, **kwargs):
+    return [{"link": "https://www.linkedin.com/in/john-doe"}]
+
+def test_find_user_linkedin_url(monkeypatch):
+    monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    url = asyncio.run(mod.find_user_linkedin_url("John Doe"))
+    assert url == "https://www.linkedin.com/in/john-doe"
+

--- a/tests/test_find_company_info.py
+++ b/tests/test_find_company_info.py
@@ -1,0 +1,19 @@
+import asyncio
+from utils import find_company_info as mod
+
+async def fake_search(query: str, *args, **kwargs):
+    if "site:linkedin.com" in query:
+        return [{"link": "https://www.linkedin.com/company/foo"}]
+    return [{"link": "https://foo.com"}]
+
+async def fake_get_external_links(url: str):
+    return ["https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Ffoo.com%2F&trk=about_website"]
+
+def test_find_company_details(monkeypatch):
+    monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    monkeypatch.setattr(mod, "get_external_links", fake_get_external_links)
+    result = asyncio.run(mod.find_company_details("Foo"))
+    assert result["linkedin_url"] == "https://www.linkedin.com/company/foo"
+    assert result["company_website"] == "https://foo.com/"
+    assert result["company_domain"] == "foo.com"
+

--- a/tests/test_find_users.py
+++ b/tests/test_find_users.py
@@ -1,0 +1,19 @@
+import csv
+from pathlib import Path
+from utils import find_users_by_name_and_keywords as mod
+
+async def fake_find(full_name: str, search_keywords: str = ""):
+    return f"https://www.linkedin.com/in/{full_name.lower().replace(' ', '')}"
+
+def test_find_users(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "find_user_linkedin_url", fake_find)
+    input_file = tmp_path / "in.csv"
+    with input_file.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["full_name", "search_keywords"])
+        writer.writeheader()
+        writer.writerow({"full_name": "John Doe", "search_keywords": ""})
+    output_file = tmp_path / "out.csv"
+    mod.find_users(input_file, output_file)
+    rows = list(csv.DictReader(output_file.open()))
+    assert rows[0]["user_linkedin_url"] == "https://www.linkedin.com/in/johndoe"
+

--- a/tests/test_linkedin_search_to_csv.py
+++ b/tests/test_linkedin_search_to_csv.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from utils import linkedin_search_to_csv as mod
+
+async def fake_search(*args, **kwargs):
+    return [
+        {"link": "https://www.linkedin.com/in/jane"},
+        {"link": "https://example.com"},
+    ]
+
+def test_linkedin_search_to_csv(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    out_file = tmp_path / "out.csv"
+    mod.linkedin_search_to_csv("query", 2, str(out_file))
+    content = out_file.read_text().splitlines()
+    assert content[0].strip() == "user_linkedin_url"
+    assert "https://www.linkedin.com/in/jane" in content[1]
+

--- a/tests/test_openai_sample.py
+++ b/tests/test_openai_sample.py
@@ -1,0 +1,16 @@
+import sys
+from types import SimpleNamespace
+from utils import openai_sample as mod
+
+class DummyClient:
+    def __init__(self, api_key=None):
+        self.responses = SimpleNamespace(create=lambda **kw: SimpleNamespace(output_text="hi"))
+
+def test_openai_main(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: DummyClient())
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(sys, "argv", ["openai_sample.py", "hello"])
+    mod.main()
+    captured = capsys.readouterr()
+    assert "hi" in captured.out
+

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+import aiohttp
+from typing import List, Optional
+from urllib.parse import urlparse, urlunparse
+
+
+async def search_google_serper(
+    query: str,
+    number_of_results: int = 10,
+    offset: int = 0,
+    as_oq: Optional[str] = None,
+) -> List[dict]:
+    """Query Google via Serper.dev and return results as dictionaries."""
+
+    serper_key = os.getenv("SERPER_API_KEY")
+    if not serper_key:
+        raise RuntimeError("SERPER_API_KEY environment variable is not set")
+
+    base_url = "https://google.serper.dev/search"
+    page = offset + 1
+    all_items: list[dict] = []
+    seen_links: set[str] = set()
+
+    def _extract_block_results(block: str, data: list[dict]) -> list[dict]:
+        mapped: list[dict] = []
+        if block == "organic":
+            for it in data:
+                link = it.get("link")
+                if link:
+                    mapped.append(it)
+        elif block == "images":
+            for it in data:
+                link = it.get("imageUrl") or it.get("link") or it.get("source")
+                if link:
+                    mapped.append(
+                        {
+                            "title": it.get("title"),
+                            "link": link,
+                            "type": "image",
+                            "thumbnail": it.get("thumbnailUrl") or it.get("thumbnail"),
+                        }
+                    )
+        elif block == "news":
+            for it in data:
+                link = it.get("link")
+                if link:
+                    mapped.append(it)
+        return mapped
+
+    async with aiohttp.ClientSession() as session:
+        while len(all_items) < number_of_results:
+            payload = {
+                "q": query if not as_oq else f"{query} {as_oq}",
+                "gl": "us",
+                "hl": "en",
+                "autocorrect": True,
+                "page": page,
+                "type": "search",
+            }
+            headers = {"X-API-KEY": serper_key, "Content-Type": "application/json"}
+
+            async with session.post(base_url, headers=headers, json=payload) as resp:
+                resp.raise_for_status()
+                result = await resp.json()
+
+            page_items: list[dict] = []
+            for block_name in ("organic", "images", "news"):
+                data = result.get(block_name) or []
+                page_items.extend(_extract_block_results(block_name, data))
+
+            new_added = 0
+            for it in page_items:
+                link = it["link"]
+                if link not in seen_links:
+                    seen_links.add(link)
+                    all_items.append(it)
+                    new_added += 1
+                    if len(all_items) >= number_of_results:
+                        break
+            if new_added == 0:
+                break
+
+            page += 1
+
+    return all_items[:number_of_results]
+
+
+def extract_user_linkedin_page(url: str) -> str:
+    """Return the canonical LinkedIn profile URL without query parameters."""
+    parsed = urlparse(url)
+    clean = parsed._replace(query="", fragment="")
+    return urlunparse(clean)

--- a/utils/find_a_user_by_name_and_keywords.py
+++ b/utils/find_a_user_by_name_and_keywords.py
@@ -7,103 +7,13 @@ import asyncio
 import json
 import logging
 import os
-from typing import List, Optional
+from typing import Optional
 from urllib.parse import urlparse, urlunparse
 
-import aiohttp
-
+from utils.common import search_google_serper, extract_user_linkedin_page
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-
-async def search_google_serper(
-    query: str,
-    number_of_results: int = 10,
-    offset: int = 0,
-    as_oq: Optional[str] = None,
-) -> List[dict]:
-    """Query Google via Serper.dev and return results as dictionaries."""
-
-    serper_key = os.getenv("SERPER_API_KEY")
-    if not serper_key:
-        raise RuntimeError("SERPER_API_KEY environment variable is not set")
-
-    base_url = "https://google.serper.dev/search"
-    page = offset + 1
-    all_items: list[dict] = []
-    seen_links: set[str] = set()
-
-    def _extract_block_results(block: str, data: list[dict]) -> list[dict]:
-        mapped: list[dict] = []
-        if block == "organic":
-            for it in data:
-                link = it.get("link")
-                if link:
-                    mapped.append(it)
-        elif block == "images":
-            for it in data:
-                link = it.get("imageUrl") or it.get("link") or it.get("source")
-                if link:
-                    mapped.append(
-                        {
-                            "title": it.get("title"),
-                            "link": link,
-                            "type": "image",
-                            "thumbnail": it.get("thumbnailUrl") or it.get("thumbnail"),
-                        }
-                    )
-        elif block == "news":
-            for it in data:
-                link = it.get("link")
-                if link:
-                    mapped.append(it)
-        return mapped
-
-    async with aiohttp.ClientSession() as session:
-        while len(all_items) < number_of_results:
-            payload = {
-                "q": query if not as_oq else f"{query} {as_oq}",
-                "gl": "us",
-                "hl": "en",
-                "autocorrect": True,
-                "page": page,
-                "type": "search",
-            }
-            headers = {"X-API-KEY": serper_key, "Content-Type": "application/json"}
-
-            async with session.post(base_url, headers=headers, json=payload) as resp:
-                resp.raise_for_status()
-                result = await resp.json()
-
-            page_items: list[dict] = []
-            for block_name in ("organic", "images", "news"):
-                data = result.get(block_name) or []
-                page_items.extend(_extract_block_results(block_name, data))
-
-            new_added = 0
-            for it in page_items:
-                link = it["link"]
-                if link not in seen_links:
-                    seen_links.add(link)
-                    all_items.append(it)
-                    new_added += 1
-                    if len(all_items) >= number_of_results:
-                        break
-            if new_added == 0:
-                break
-
-            page += 1
-
-    return all_items[:number_of_results]
-
-
-def extract_user_linkedin_page(url: str) -> str:
-    """Return the canonical LinkedIn profile URL without query parameters."""
-    parsed = urlparse(url)
-    clean = parsed._replace(query="", fragment="")
-    return urlunparse(clean)
-
 
 async def find_user_linkedin_url(full_name: str, search_keywords: str = "") -> str:
     """Return the LinkedIn profile URL for a person using Google search."""

--- a/utils/find_company_info.py
+++ b/utils/find_company_info.py
@@ -6,7 +6,6 @@ import argparse
 import asyncio
 import json
 import logging
-import os
 import re
 import urllib.parse
 from typing import List, Optional
@@ -14,6 +13,7 @@ from urllib.parse import urlparse, urlunparse
 
 import aiohttp
 from bs4 import BeautifulSoup
+from utils.common import search_google_serper
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -22,83 +22,6 @@ logging.basicConfig(
 )
 
 
-async def search_google_serper(
-    query: str,
-    number_of_results: int = 10,
-    offset: int = 0,
-    as_oq: Optional[str] = None,
-) -> List[dict]:
-    """Query Google via Serper.dev and return results as dictionaries."""
-
-    serper_key = os.getenv("SERPER_API_KEY")
-    if not serper_key:
-        raise RuntimeError("SERPER_API_KEY environment variable is not set")
-
-    base_url = "https://google.serper.dev/search"
-    page = offset + 1
-    all_items: list[dict] = []
-    seen_links: set[str] = set()
-
-    def _extract_block_results(block: str, data: list[dict]) -> list[dict]:
-        mapped: list[dict] = []
-        if block == "organic":
-            for it in data:
-                link = it.get("link")
-                if link:
-                    mapped.append(it)
-        elif block == "images":
-            for it in data:
-                link = it.get("imageUrl") or it.get("link") or it.get("source")
-                if link:
-                    mapped.append({
-                        "title": it.get("title"),
-                        "link": link,
-                        "type": "image",
-                        "thumbnail": it.get("thumbnailUrl") or it.get("thumbnail"),
-                    })
-        elif block == "news":
-            for it in data:
-                link = it.get("link")
-                if link:
-                    mapped.append(it)
-        return mapped
-
-    async with aiohttp.ClientSession() as session:
-        while len(all_items) < number_of_results:
-            payload = {
-                "q": query if not as_oq else f"{query} {as_oq}",
-                "gl": "us",
-                "hl": "en",
-                "autocorrect": True,
-                "page": page,
-                "type": "search",
-            }
-            headers = {"X-API-KEY": serper_key, "Content-Type": "application/json"}
-
-            async with session.post(base_url, headers=headers, json=payload) as resp:
-                resp.raise_for_status()
-                result = await resp.json()
-
-            page_items: list[dict] = []
-            for block_name in ("organic", "images", "news"):
-                data = result.get(block_name) or []
-                page_items.extend(_extract_block_results(block_name, data))
-
-            new_added = 0
-            for it in page_items:
-                link = it["link"]
-                if link not in seen_links:
-                    seen_links.add(link)
-                    all_items.append(it)
-                    new_added += 1
-                    if len(all_items) >= number_of_results:
-                        break
-            if new_added == 0:
-                break
-
-            page += 1
-
-    return all_items[:number_of_results]
 
 
 def extract_company_page(url: str) -> str:

--- a/utils/linkedin_search_to_csv.py
+++ b/utils/linkedin_search_to_csv.py
@@ -5,110 +5,20 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
-import json
 import logging
-import os
-from typing import List, Optional
 from urllib.parse import urlparse, urlunparse
 
-import aiohttp
+from utils.common import search_google_serper, extract_user_linkedin_page
 
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-
-async def search_google_serper(
-    query: str,
-    number_of_results: int = 10,
-    offset: int = 0,
-    as_oq: Optional[str] = None,
-) -> List[dict]:
-    """Query Google via Serper.dev and return results as dictionaries."""
-
-    serper_key = os.getenv("SERPER_API_KEY")
-    if not serper_key:
-        raise RuntimeError("SERPER_API_KEY environment variable is not set")
-
-    base_url = "https://google.serper.dev/search"
-    page = offset + 1
-    all_items: list[dict] = []
-    seen_links: set[str] = set()
-
-    def _extract_block_results(block: str, data: list[dict]) -> list[dict]:
-        mapped: list[dict] = []
-        if block == "organic":
-            for it in data:
-                link = it.get("link")
-                if link:
-                    mapped.append(it)
-        elif block == "images":
-            for it in data:
-                link = it.get("imageUrl") or it.get("link") or it.get("source")
-                if link:
-                    mapped.append({
-                        "title": it.get("title"),
-                        "link": link,
-                        "type": "image",
-                        "thumbnail": it.get("thumbnailUrl") or it.get("thumbnail"),
-                    })
-        elif block == "news":
-            for it in data:
-                link = it.get("link")
-                if link:
-                    mapped.append(it)
-        return mapped
-
-    async with aiohttp.ClientSession() as session:
-        while len(all_items) < number_of_results:
-            payload = {
-                "q": query if not as_oq else f"{query} {as_oq}",
-                "gl": "us",
-                "hl": "en",
-                "autocorrect": True,
-                "page": page,
-                "type": "search",
-            }
-            headers = {"X-API-KEY": serper_key, "Content-Type": "application/json"}
-
-            async with session.post(base_url, headers=headers, json=payload) as resp:
-                resp.raise_for_status()
-                result = await resp.json()
-
-            page_items: list[dict] = []
-            for block_name in ("organic", "images", "news"):
-                data = result.get(block_name) or []
-                page_items.extend(_extract_block_results(block_name, data))
-
-            new_added = 0
-            for it in page_items:
-                link = it["link"]
-                if link not in seen_links:
-                    seen_links.add(link)
-                    all_items.append(it)
-                    new_added += 1
-                    if len(all_items) >= number_of_results:
-                        break
-            if new_added == 0:
-                break
-
-            page += 1
-
-    return all_items[:number_of_results]
-
-
-def extract_user_linkedin_page(url: str) -> str:
-    """Return the canonical LinkedIn profile URL without query parameters."""
-    parsed = urlparse(url)
-    clean = parsed._replace(query="", fragment="")
-    return urlunparse(clean)
-
-
 def linkedin_search_to_csv(query: str, number_of_results: int, output_file: str) -> None:
     """Search Google for LinkedIn profile URLs and write them to a CSV."""
 
     results = asyncio.run(search_google_serper(query, number_of_results))
-    linkedin_urls: List[str] = []
+    linkedin_urls: list[str] = []
 
     for item in results:
         link = item.get("link", "")


### PR DESCRIPTION
## Summary
- move `search_google_serper` and `extract_user_linkedin_page` into `utils/common.py`
- update utilities to use the shared helpers
- add pytest suite with stubs for missing deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7f0ccc00832d98d8dd5e3e796283