### PR TITLE
Simplify run:command usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Common actions:
 3. Run a utility inside the container
 
    ```bash
-task run:command -- python utils/openai_sample.py "Hello!"
-```
+   task run:command openai_sample "Hello!"
+   ```
 
    The output of the command is saved to `output/run.log` in your working
    directory.
@@ -55,7 +55,7 @@ To keep files produced by a command, write them to `/workspace` inside the
 container. The `output/` directory on your host maps to this path. For example:
 
 ```bash
-task run:command -- python utils/linkedin_search_to_csv.py \
+task run:command linkedin_search_to_csv \
     "site:linkedin.com/in growth hacker" /workspace/results.csv -n 20
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,11 +15,15 @@ tasks:
       - docker build -t {{.IMAGE}} .
 
   run:command:
-    desc: Run a command inside the Docker image and capture output
+    desc: Run a utility inside the Docker image and capture output
     cmds:
       - mkdir -p output
       - |
-        echo Running: docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} {{.CLI_ARGS}}
-        docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} {{.CLI_ARGS}} 2>&1 | tee output/run.log
+          set -e
+          set -- {{.CLI_ARGS}}
+          cmd="$1"
+          shift
+          echo Running: docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} -- python utils/${cmd}.py "$@"
+          docker run --env-file .env -v $(pwd)/output:/workspace {{.IMAGE}} -- python utils/${cmd}.py "$@" 2>&1 | tee output/run.log
       - mkdir -p /tmp/outputs
       - cp -a output/* /tmp/outputs/ 2>/dev/null || true

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -6,16 +6,10 @@ This page provides usage instructions for the sample scripts included in the `ut
 
 `openai_sample.py` sends a prompt to OpenAI and prints the response returned from the API. The script requires the `OPENAI_API_KEY` environment variable.
 
-Run it from the project root (or inside the container) with a prompt:
+Run it with the Taskfile:
 
 ```bash
-python utils/openai_sample.py "Hello!"
-```
-
-Or using the Taskfile after building the image:
-
-```bash
-task run:command -- python utils/openai_sample.py "Hello!"
+task run:command openai_sample "Hello!"
 ```
 
 The script prints the text from the `responses.create` call.
@@ -27,13 +21,7 @@ The script prints the text from the `responses.create` call.
 Example usage fetching 20 results:
 
 ```bash
-python utils/linkedin_search_to_csv.py "site:linkedin.com/in growth hacker" results.csv -n 20
-```
-
-Or using the Taskfile with a mounted volume to access the output file locally:
-
-```bash
-task run:command -- python utils/linkedin_search_to_csv.py \
+task run:command linkedin_search_to_csv \
     "site:linkedin.com/in growth hacker" /workspace/results.csv -n 20
 ```
 The Taskfile mounts the `output/` directory from your host to `/workspace`
@@ -48,7 +36,7 @@ After the command finishes, everything in `output/` is also copied to
 Run it with the company name and optional location:
 
 ```bash
-task run:command -- python utils/find_company_info.py "Dhisana" -l "San Francisco"
+task run:command find_company_info "Dhisana" -l "San Francisco"
 ```
 
 The script prints a JSON object containing `company_website`, `company_domain` and `linkedin_url`.
@@ -60,13 +48,7 @@ The script prints a JSON object containing `company_website`, `company_domain` a
 Run it with a name and keywords:
 
 ```bash
-python utils/find_a_user_by_name_and_keywords.py "Jane Doe" "growth marketing"
-```
-
-Or using the Taskfile inside the container:
-
-```bash
-task run:command -- python utils/find_a_user_by_name_and_keywords.py \
+task run:command find_a_user_by_name_and_keywords \
     "Jane Doe" "growth marketing"
 ```
 
@@ -81,13 +63,7 @@ using Google search through Serper.dev and writes the results to a new CSV file.
 Run it with an input and output file:
 
 ```bash
-python utils/find_users_by_name_and_keywords.py input.csv output.csv
-```
-
-Or using the Taskfile inside the container:
-
-```bash
-task run:command -- python utils/find_users_by_name_and_keywords.py \
+task run:command find_users_by_name_and_keywords \
     /workspace/input.csv /workspace/output.csv
 ```
 


### PR DESCRIPTION
## Summary
- adjust `run:command` task to take a command name and run the script automatically
- update README with simplified task invocation
- revise docs to only show `task run:command` usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a81cd4bd4832db0733014d4137985