### PR TITLE
Normalize LinkedIn URLs

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -17,6 +17,7 @@ The script prints the text from the `responses.create` call.
 ## Search LinkedIn URLs
 
 `linkedin_search_to_csv.py` queries Google through Serper.dev to find LinkedIn profile URLs and writes them to a CSV file. It requires the `SERPER_API_KEY` environment variable.
+All LinkedIn URLs in the output are normalized to the `https://www.linkedin.com/in/<id>` format.
 
 Example usage fetching 20 results:
 
@@ -33,6 +34,7 @@ After the command finishes, everything in `output/` is also copied to
 ## Find Company Info
 
 `find_company_info.py` looks up a company's website, primary domain and LinkedIn page using Google search. It uses the `SERPER_API_KEY` environment variable for Google queries.
+The LinkedIn URL returned is normalized to the `https://www.linkedin.com/company/<id>` form.
 
 Run it with the company name and optional location:
 
@@ -45,6 +47,7 @@ The script prints a JSON object containing `company_website`, `company_domain` a
 ## Find User by Name and Keywords
 
 `find_a_user_by_name_and_keywords.py` searches Google via Serper.dev for a person's LinkedIn profile. Provide the person's full name and optional additional keywords. The script outputs a JSON object containing the full name, the LinkedIn profile URL and the search keywords used.
+The profile URL is normalized to the `https://www.linkedin.com/in/<id>` format.
 
 Run it with a name and keywords:
 
@@ -60,6 +63,7 @@ The script prints the resulting JSON to stdout.
 `find_users_by_name_and_keywords.py` reads a CSV containing `full_name` and
 `search_keywords` columns. For each row it looks up the person's LinkedIn profile
 using Google search through Serper.dev and writes the results to a new CSV file.
+All profile URLs in the output are normalized to the `https://www.linkedin.com/in/<id>` form.
 
 Run it with an input and output file. When using the Docker based `task` command
 the paths should point inside the container (the local `output/` directory is

--- a/tests/test_url_normalization.py
+++ b/tests/test_url_normalization.py
@@ -1,0 +1,15 @@
+import pytest
+
+from utils.common import extract_user_linkedin_page
+from utils.find_company_info import extract_company_page
+
+
+def test_extract_user_linkedin_page_normalization():
+    raw = "http://linkedin.com/in/john-doe/?utm=foo"
+    assert extract_user_linkedin_page(raw) == "https://www.linkedin.com/in/john-doe"
+
+
+def test_extract_company_page_normalization():
+    raw = "https://uk.linkedin.com/company/acme-inc/?trk=public"
+    assert extract_company_page(raw) == "https://www.linkedin.com/company/acme-inc"
+

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import aiohttp
 from typing import List, Optional
 from urllib.parse import urlparse, urlunparse
@@ -88,7 +89,22 @@ async def search_google_serper(
 
 
 def extract_user_linkedin_page(url: str) -> str:
-    """Return the canonical LinkedIn profile URL without query parameters."""
-    parsed = urlparse(url)
-    clean = parsed._replace(query="", fragment="")
-    return urlunparse(clean)
+    """Return the canonical LinkedIn profile URL."""
+    if not url:
+        return ""
+
+    # Replace different schemes or subdomains with the standard one
+    normalized = re.sub(
+        r"(https?://)?([\w\-]+\.)?linkedin\.com",
+        "https://www.linkedin.com",
+        url,
+    )
+
+    parsed = urlparse(normalized)
+    parts = parsed.path.strip("/").split("/")
+
+    if len(parts) >= 2 and parts[0] in {"in", "pub"}:
+        slug = parts[1]
+        return f"https://www.linkedin.com/in/{slug}"
+
+    return ""

--- a/utils/find_company_info.py
+++ b/utils/find_company_info.py
@@ -28,10 +28,20 @@ def extract_company_page(url: str) -> str:
     """Return the canonical LinkedIn company page URL."""
     if not url:
         return ""
-    normalized = re.sub(r"(https?://)?([\w\-]+\.)?linkedin\.com", "https://www.linkedin.com", url)
-    match = re.match(r"https://www.linkedin.com/company/([\w\-]+)", normalized)
-    if match:
-        return f"https://www.linkedin.com/company/{match.group(1)}"
+
+    normalized = re.sub(
+        r"(https?://)?([\w\-]+\.)?linkedin\.com",
+        "https://www.linkedin.com",
+        url,
+    )
+
+    parsed = urlparse(normalized)
+    parts = parsed.path.strip("/").split("/")
+
+    if len(parts) >= 2 and parts[0] == "company":
+        slug = parts[1]
+        return f"https://www.linkedin.com/company/{slug}"
+
     return ""
 
 


### PR DESCRIPTION
## Summary
- normalize LinkedIn profile links
- normalize LinkedIn company links
- document normalization of output URLs in `docs/utils_usage.md`
- test URL normalization helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b3fe90120832db48b9be8134ef11c