### PR TITLE
Add LinkedIn search by job title

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -58,6 +58,22 @@ task run:command -- find_a_user_by_name_and_keywords \
 
 The script prints the resulting JSON to stdout.
 
+## Find User by Job Title and Company
+
+`find_user_by_job_title.py` searches Google via Serper.dev for a LinkedIn profile
+matching a specific job title at a company. Provide the job title, the company
+name and optional extra keywords. The returned profile URL is normalized to the
+`https://www.linkedin.com/in/<id>` format.
+
+Run it with a title, company and keywords:
+
+```bash
+task run:command -- find_user_by_job_title \
+    "CEO" "Costco" retail
+```
+
+The script prints the resulting JSON to stdout.
+
 ## Find Users by Name and Keywords
 
 `find_users_by_name_and_keywords.py` reads a CSV containing `full_name` and

--- a/tests/test_find_by_job_title.py
+++ b/tests/test_find_by_job_title.py
@@ -1,0 +1,10 @@
+import asyncio
+from utils import find_user_by_job_title as mod
+
+async def fake_search(*args, **kwargs):
+    return [{"link": "https://www.linkedin.com/in/jane-doe"}]
+
+def test_find_user_by_job_title(monkeypatch):
+    monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    url = asyncio.run(mod.find_user_linkedin_url_by_job_title("CEO", "Acme"))
+    assert url == "https://www.linkedin.com/in/jane-doe"

--- a/utils/find_user_by_job_title.py
+++ b/utils/find_user_by_job_title.py
@@ -1,0 +1,74 @@
+"""Utility to find a LinkedIn profile by job title and company."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from urllib.parse import urlparse
+
+from utils.common import search_google_serper, extract_user_linkedin_page
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+async def find_user_linkedin_url_by_job_title(
+    job_title: str,
+    company_name: str,
+    search_keywords: str = "",
+) -> str:
+    """Return the LinkedIn profile URL for a title at a given company."""
+    if not job_title or not company_name:
+        return ""
+
+    query = f'site:linkedin.com/in "{company_name}" "{job_title}"'
+    if search_keywords:
+        query += f' "{search_keywords}"'
+    query += ' -intitle:"profiles"'
+
+    logger.info("Querying Google: %s", query)
+    results = await search_google_serper(query.strip(), 3)
+    for item in results:
+        link = item.get("link", "")
+        if not link:
+            continue
+        parsed = urlparse(link)
+        if "linkedin.com/in" in (parsed.netloc + parsed.path):
+            return extract_user_linkedin_page(link)
+
+    logger.info("LinkedIn profile not found")
+    return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Find a LinkedIn profile by job title and company using Google search",
+    )
+    parser.add_argument("job_title", help="User's job title")
+    parser.add_argument("company_name", help="Company name")
+    parser.add_argument(
+        "search_keywords",
+        nargs="?",
+        default="",
+        help="Additional keywords to refine the search",
+    )
+    args = parser.parse_args()
+
+    url = asyncio.run(
+        find_user_linkedin_url_by_job_title(
+            args.job_title, args.company_name, args.search_keywords
+        )
+    )
+    result = {
+        "job_title": args.job_title,
+        "company_name": args.company_name,
+        "user_linkedin_url": url,
+        "search_keywords": args.search_keywords,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `find_user_by_job_title` utility to look up a LinkedIn profile based on a job title and company name
- document new utility in `docs/utils_usage.md`
- test the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b4261f598832daa0d124da1e38815