### PR TITLE
Add Dhisana webhook lead utility

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -100,3 +100,15 @@ task run:command_local_mapping -- /tmp find_users_by_name_and_keywords \
 
 The resulting CSV contains `full_name`, `user_linkedin_url` and
 `search_keywords` for each entry.
+
+## Push Lead to Dhisana Webhook
+
+`push_lead_to_dhisana_webhook.py` sends a lead's details to a Dhisana webhook endpoint. Provide the full name and optionally the LinkedIn URL and email address. The script uses the `DHISANA_API_KEY` environment variable for authentication. The webhook URL is read from `DHISANA_WEBHOOK_URL` or can be supplied with `--webhook_url`.
+
+Example usage:
+
+```bash
+task run:command -- push_lead_to_dhisana_webhook \
+    "Jane Doe" --linkedin_url https://www.linkedin.com/in/janedoe \
+    --email jane@example.com
+```

--- a/tests/test_push_lead_to_dhisana_webhook.py
+++ b/tests/test_push_lead_to_dhisana_webhook.py
@@ -1,0 +1,50 @@
+import asyncio
+from utils import push_lead_to_dhisana_webhook as mod
+
+class DummyResponse:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+class DummySession:
+    def __init__(self):
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, headers=None, json=None):
+        self.calls.append((url, headers, json))
+        return DummyResponse()
+
+def test_push_lead(monkeypatch):
+    session = DummySession()
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("DHISANA_API_KEY", "key")
+    result = asyncio.run(
+        mod.push_lead_to_dhisana_webhook(
+            "John Doe",
+            linkedin_url="https://linkedin.com/in/johndoe",
+            webhook_url="http://hook",
+        )
+    )
+    assert result is True
+    assert session.calls[0][0] == "http://hook"
+    assert session.calls[0][1]["X-API-Key"] == "key"
+    assert session.calls[0][2][0]["user_linkedin_url"] == "https://linkedin.com/in/johndoe"
+
+def test_skip_if_no_data(monkeypatch):
+    session = DummySession()
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("DHISANA_API_KEY", "key")
+    result = asyncio.run(mod.push_lead_to_dhisana_webhook("Jane" , webhook_url="http://hook"))
+    assert result is False
+    assert session.calls == []

--- a/utils/push_lead_to_dhisana_webhook.py
+++ b/utils/push_lead_to_dhisana_webhook.py
@@ -1,0 +1,83 @@
+"""Utility to push lead information to a Dhisana webhook."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from typing import Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+async def push_lead_to_dhisana_webhook(
+    full_name: str,
+    linkedin_url: str = "",
+    email: str = "",
+    webhook_url: Optional[str] = None,
+) -> bool:
+    """Send lead details to the Dhisana webhook.
+
+    Returns ``True`` when a request was made. If neither ``linkedin_url`` nor
+    ``email`` is provided the function returns ``False`` without calling the
+    webhook.
+    """
+
+    if not linkedin_url and not email:
+        logger.info("Skipping push because no linkedin_url or email provided")
+        return False
+
+    api_key = os.getenv("DHISANA_API_KEY")
+    if not api_key:
+        raise RuntimeError("DHISANA_API_KEY environment variable is not set")
+
+    if not webhook_url:
+        webhook_url = os.getenv("DHISANA_WEBHOOK_URL")
+    if not webhook_url:
+        raise RuntimeError(
+            "Webhook URL not provided and DHISANA_WEBHOOK_URL is not set"
+        )
+
+    payload = [
+        {
+            "full_name": full_name,
+            "email": email,
+            "user_linkedin_url": linkedin_url,
+        }
+    ]
+
+    headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(webhook_url, headers=headers, json=payload) as resp:
+            resp.raise_for_status()
+            logger.info("Lead pushed to Dhisana webhook")
+            return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Push a lead to a Dhisana webhook"
+    )
+    parser.add_argument("full_name", help="Lead's full name")
+    parser.add_argument("--linkedin_url", default="", help="LinkedIn profile URL")
+    parser.add_argument("--email", default="", help="Email address")
+    parser.add_argument(
+        "--webhook_url",
+        help="Webhook URL (defaults to DHISANA_WEBHOOK_URL)",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        push_lead_to_dhisana_webhook(
+            args.full_name, args.linkedin_url, args.email, args.webhook_url
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `push_lead_to_dhisana_webhook` utility for sending lead details
- document pushing leads to Dhisana
- test posting to webhook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b44a334f0832db2b4e16144731047