### PR TITLE
Add tags and notes to Dhisana webhook

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -103,12 +103,12 @@ The resulting CSV contains `full_name`, `user_linkedin_url` and
 
 ## Push Lead to Dhisana Webhook
 
-`push_lead_to_dhisana_webhook.py` sends a lead's details to a Dhisana webhook endpoint. Provide the full name and optionally the LinkedIn URL and email address. The script uses the `DHISANA_API_KEY` environment variable for authentication. The webhook URL is read from `DHISANA_WEBHOOK_URL` or can be supplied with `--webhook_url`.
+`push_lead_to_dhisana_webhook.py` sends a lead's details to a Dhisana webhook endpoint. Provide the full name and optionally the LinkedIn URL, email address, tags, and notes. The script uses the `DHISANA_API_KEY` environment variable for authentication. The webhook URL is read from `DHISANA_WEBHOOK_URL` or can be supplied with `--webhook_url`.
 
 Example usage:
 
 ```bash
 task run:command -- push_lead_to_dhisana_webhook \
     "Jane Doe" --linkedin_url https://www.linkedin.com/in/janedoe \
-    --email jane@example.com
+    --email jane@example.com --tags prospect --notes "Met at conference"
 ```

--- a/tests/test_push_lead_to_dhisana_webhook.py
+++ b/tests/test_push_lead_to_dhisana_webhook.py
@@ -33,13 +33,18 @@ def test_push_lead(monkeypatch):
         mod.push_lead_to_dhisana_webhook(
             "John Doe",
             linkedin_url="https://linkedin.com/in/johndoe",
+            tags="vip",
+            notes="important",
             webhook_url="http://hook",
         )
     )
     assert result is True
     assert session.calls[0][0] == "http://hook"
     assert session.calls[0][1]["X-API-Key"] == "key"
-    assert session.calls[0][2][0]["user_linkedin_url"] == "https://linkedin.com/in/johndoe"
+    payload = session.calls[0][2][0]
+    assert payload["user_linkedin_url"] == "https://linkedin.com/in/johndoe"
+    assert payload["tags"] == "vip"
+    assert payload["notes"] == "important"
 
 def test_skip_if_no_data(monkeypatch):
     session = DummySession()

--- a/utils/push_lead_to_dhisana_webhook.py
+++ b/utils/push_lead_to_dhisana_webhook.py
@@ -18,13 +18,16 @@ async def push_lead_to_dhisana_webhook(
     full_name: str,
     linkedin_url: str = "",
     email: str = "",
+    tags: str = "",
+    notes: str = "",
     webhook_url: Optional[str] = None,
 ) -> bool:
     """Send lead details to the Dhisana webhook.
 
     Returns ``True`` when a request was made. If neither ``linkedin_url`` nor
     ``email`` is provided the function returns ``False`` without calling the
-    webhook.
+    webhook. ``tags`` and ``notes`` are optional strings that will be included
+    in the payload if provided.
     """
 
     if not linkedin_url and not email:
@@ -47,6 +50,8 @@ async def push_lead_to_dhisana_webhook(
             "full_name": full_name,
             "email": email,
             "user_linkedin_url": linkedin_url,
+            "tags": tags,
+            "notes": notes,
         }
     ]
 
@@ -66,6 +71,8 @@ def main() -> None:
     parser.add_argument("full_name", help="Lead's full name")
     parser.add_argument("--linkedin_url", default="", help="LinkedIn profile URL")
     parser.add_argument("--email", default="", help="Email address")
+    parser.add_argument("--tags", default="", help="Comma separated tags")
+    parser.add_argument("--notes", default="", help="Additional notes")
     parser.add_argument(
         "--webhook_url",
         help="Webhook URL (defaults to DHISANA_WEBHOOK_URL)",
@@ -74,7 +81,12 @@ def main() -> None:
 
     asyncio.run(
         push_lead_to_dhisana_webhook(
-            args.full_name, args.linkedin_url, args.email, args.webhook_url
+            args.full_name,
+            args.linkedin_url,
+            args.email,
+            args.tags,
+            args.notes,
+            args.webhook_url,
         )
     )
 


### PR DESCRIPTION
## Summary
- push_lead_to_dhisana_webhook can take tags and notes
- document tags/notes usage and update example
- test for new payload fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b483dcfc8832daac7720541c4f316