### PR TITLE
Install Codex CLI in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,16 @@ RUN apt-get update && \
         libcups2 libxss1 libdrm2 libgbm1 \
         libgtk-3-0 libasound2 libx11-xcb1 \
         libxcb1 libxcomposite1 libxdamage1 libxrandr2 \
+        nodejs npm \
     xdg-utils fonts-liberation && \
     rm -rf /var/lib/apt/lists/*
+
+# Install OpenAI Codex CLI and convenience wrapper
+RUN npm install -g @openai/codex && \
+    ln -s /usr/bin/nodejs /usr/local/bin/node && \
+    rm -rf /root/.npm && \
+    chmod +x /usr/local/bin/codex
+COPY scripts/codex-auto.sh /usr/local/bin/codex-auto
 
 # Install Taskfile runner for convenient local usage
 RUN curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -89,3 +89,19 @@ python -m utils.find_users_by_name_and_keywords input.csv output.csv
 Place additional stand‑alone scripts inside the `utils/` directory. They will be available inside the Docker image once built.
 
 See [Using the utilities](docs/utils_usage.md) for examples of running the sample scripts.
+
+## OpenAI Codex CLI
+
+The Docker image now comes with the [OpenAI Codex CLI](https://github.com/openai/codex)
+installed globally via `npm`. Codex helps you explore and refactor code using
+natural language prompts.
+
+1. Ensure your `OPENAI_API_KEY` is set in `.env` or exported in your shell.
+2. Start the CLI in auto‑edit mode using the wrapper script:
+
+   ```bash
+   codex-auto "Explain this repo"
+   ```
+
+Codex will read files in the current directory, propose edits and apply them
+automatically while still asking before running shell commands.

--- a/docs/api_keys.md
+++ b/docs/api_keys.md
@@ -30,4 +30,4 @@ SERPER_API_KEY=your_serper_key
 DHISANA_API_KEY=your_dhisana_key
 ```
 
-Save the file. The utilities will read these variables when run.
+Save the file. The utilities and the Codex CLI will read these variables when run.

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -129,3 +129,15 @@ task run:command -- push_company_to_dhisana_webhook \
     --linkedin_url https://www.linkedin.com/company/acme \
     --tags prospect --notes "From event"
 ```
+
+## OpenAI Codex CLI
+
+The Docker image includes the Codex CLI for conversational code edits. Once your
+`OPENAI_API_KEY` is set, start it in auto-edit mode with:
+
+```bash
+codex-auto "Explain this repo"
+```
+
+Codex proposes edits and applies them to files in the repository while still
+prompting before executing shell commands.

--- a/scripts/codex-auto.sh
+++ b/scripts/codex-auto.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Wrapper to run OpenAI Codex CLI in auto edit mode
+codex --auto-edit "$@"


### PR DESCRIPTION
## Summary
- install OpenAI Codex CLI inside the Docker image
- add a small wrapper script `codex-auto` to start Codex in auto-edit mode
- document usage of the Codex CLI and auto-edit wrapper
- note that the OPENAI_API_KEY is also consumed by Codex

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b61a8a60c832da6508346b00abc65