### PR TITLE
Fix codex install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,21 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 # ─── 1️⃣  OS libs for Chromium ───────────────────────────────────────
 USER root
 RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         libnss3 libatk-bridge2.0-0 libatk1.0-0 \
         libcups2 libxss1 libdrm2 libgbm1 \
         libgtk-3-0 libasound2 libx11-xcb1 \
         libxcb1 libxcomposite1 libxdamage1 libxrandr2 \
-        nodejs npm \
+        nodejs \
     xdg-utils fonts-liberation && \
     rm -rf /var/lib/apt/lists/*
 
 # Install OpenAI Codex CLI and convenience wrapper
 RUN npm install -g @openai/codex && \
-    ln -s /usr/bin/nodejs /usr/local/bin/node && \
+    ln -s /usr/bin/node /usr/local/bin/node && \
     rm -rf /root/.npm && \
     chmod +x /usr/local/bin/codex
 COPY scripts/codex-auto.sh /usr/local/bin/codex-auto

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ See [Using the utilities](docs/utils_usage.md) for examples of running the sampl
 ## OpenAI Codex CLI
 
 The Docker image now comes with the [OpenAI Codex CLI](https://github.com/openai/codex)
-installed globally via `npm`. Codex helps you explore and refactor code using
+installed globally via `npm`. Codex requires **Node.js 22** or later, so the image installs
+Node from the official NodeSource repository. Codex helps you explore and refactor code using
 natural language prompts.
 
 1. Ensure your `OPENAI_API_KEY` is set in `.env` or exported in your shell.


### PR DESCRIPTION
## Summary
- install Node.js 22 from NodeSource
- mention Node.js 22 requirement for Codex CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b778dc124832d89e48f5c66b553c2