### PR TITLE
Add simple Flask webapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,10 @@ RUN python -m playwright install chromium && \
 COPY . /home/site/wwwroot
 WORKDIR /home/site/wwwroot
 
+EXPOSE 8080
+
 # ─── 5️⃣  ⚠️ Keep running as **root** in local dev so port-80 bind works
 #          In production you can switch back to www-data if you prefer.
 # USER www-data
 
-CMD ["bash"]
+CMD ["python", "-m", "app"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The project is contributed to and maintained by the **[Dhisana AI](https://www.d
 - `Dockerfile` – Container image definition for running the utilities in an Azure Functions compatible environment with Playwright support.
 - `requirements.txt` – Python dependencies for the utilities.
 - `.env` – Environment variables consumed by the utilities.
+- `app/` – Simple Flask web app launched when the Docker container starts.
 
 ## Prerequisites
 
@@ -106,3 +107,17 @@ natural language prompts.
 
 Codex will read files in the current directory, propose edits and apply them
 automatically while still asking before running shell commands.
+
+## Web application
+
+Building the Docker image will also install a lightweight Flask web app located
+in the `app/` directory. When the container starts without any command
+arguments, the web interface launches automatically on port `8080`:
+
+```bash
+docker run -p 8080:8080 gtm-ai-tools
+```
+
+Open <http://localhost:8080> in your browser to access the app which provides a
+simple interface for describing and running workflows as well as editing your
+environment variables.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,37 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, flash
+from dotenv import dotenv_values, set_key
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET", "dev")
+ENV_FILE = os.path.join(os.path.dirname(__file__), "..", ".env")
+
+
+def load_env():
+    return dotenv_values(ENV_FILE)
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    preview = None
+    workflow = ''
+    if request.method == 'POST':
+        workflow = request.form.get('workflow', '')
+        action = request.form.get('action')
+        if action in {'build', 'preview'}:
+            preview = workflow
+        elif action == 'run':
+            flash(f"Running workflow: {workflow}")
+    return render_template('index.html', workflow=workflow, preview=preview)
+
+
+@app.route('/settings', methods=['GET', 'POST'])
+def settings():
+    env_vars = load_env()
+    if request.method == 'POST':
+        for key in env_vars:
+            value = request.form.get(key, '')
+            set_key(ENV_FILE, key, value)
+        flash('Settings saved.')
+        return redirect(url_for('settings'))
+    return render_template('settings.html', env_vars=env_vars)

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,6 @@
+from . import app
+import os
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 8080))
+    app.run(host='0.0.0.0', port=port)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dhisana AI Agent</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    header img { height: 30px; vertical-align: middle; }
+    nav a { margin-right: 15px; }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="https://www.dhisana.ai">
+      <img src="https://www.dhisana.ai/assets/images/color-logo-no-background.svg" alt="Dhisana" />
+      Dhisana AI Agent
+    </a>
+  </header>
+  <nav>
+    <a href="{{ url_for('index') }}">Build &amp; Run Your Workflow</a>
+    <a href="{{ url_for('settings') }}">Settings</a>
+  </nav>
+
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <ul>
+      {% for m in messages %}
+        <li>{{ m }}</li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
+
+  <h2>Build &amp; Run Your Workflow</h2>
+  <form method="post">
+    <textarea name="workflow" rows="6" cols="60" placeholder="Describe what you want to build">{{ workflow }}</textarea><br>
+    <button type="submit" name="action" value="build">Build</button>
+    <button type="submit" name="action" value="preview">Preview</button>
+    <button type="submit" name="action" value="run">Run</button>
+  </form>
+
+  {% if preview %}
+  <h3>Preview</h3>
+  <pre>{{ preview }}</pre>
+  {% endif %}
+</body>
+</html>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dhisana AI Agent - Settings</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    header img { height: 30px; vertical-align: middle; }
+    nav a { margin-right: 15px; }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="https://www.dhisana.ai">
+      <img src="https://www.dhisana.ai/assets/images/color-logo-no-background.svg" alt="Dhisana" />
+      Dhisana AI Agent
+    </a>
+  </header>
+  <nav>
+    <a href="{{ url_for('index') }}">Build &amp; Run Your Workflow</a>
+    <a href="{{ url_for('settings') }}">Settings</a>
+  </nav>
+
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <ul>
+      {% for m in messages %}
+        <li>{{ m }}</li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
+
+  <h2>Settings</h2>
+  <form method="post">
+    {% for key, value in env_vars.items() %}
+      <label>{{ key }}: <input type="text" name="{{ key }}" value="{{ value }}"></label><br>
+    {% endfor %}
+    <button type="submit">Save</button>
+  </form>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ playwright-stealth
 aiohttp
 
 beautifulsoup4
+flask
+python-dotenv


### PR DESCRIPTION
## Summary
- add Flask-based web application under `app/`
- update Docker image to launch the web app on port 8080
- mention web app in README and expose run instructions
- add Flask dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b7a305fd0832dad314563af8313cb