### PR TITLE
Add utility runner to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,13 @@ docker run -p 8080:8080 gtm-ai-tools
 Open <http://localhost:8080> in your browser to access the app which provides a
 simple interface for describing and running workflows as well as editing your
 environment variables.
+
+The homepage now offers two options:
+
+1. **Run a Utility** – select any script from the `utils/` directory and provide
+   its command‑line parameters. If a script requires a CSV input you can upload
+   the file directly in the form. When a utility produces a CSV output a
+   download link will be displayed. Plain text output is shown in the page.
+2. **Build My Own Workflow** – describe a workflow in free text. The current
+   implementation simply previews the text or flashes that the workflow would
+   run; additional functionality can be added later.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,16 @@
 import os
-from flask import Flask, render_template, request, redirect, url_for, flash
+import shlex
+import subprocess
+import tempfile
+from flask import (
+    Flask,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    send_from_directory,
+)
 from dotenv import dotenv_values, set_key
 
 app = Flask(__name__)
@@ -11,18 +22,74 @@ def load_env():
     return dotenv_values(ENV_FILE)
 
 
+def _list_utils() -> list[str]:
+    """Return available utility modules from the utils package."""
+    utils_dir = os.path.join(os.path.dirname(__file__), "..", "utils")
+    items = []
+    for name in os.listdir(utils_dir):
+        if name.endswith(".py"):
+            items.append(name[:-3])
+    return sorted(items)
+
+
 @app.route('/', methods=['GET', 'POST'])
 def index():
     preview = None
     workflow = ''
+    util_output = None
+    download_name = None
+    utils_list = _list_utils()
     if request.method == 'POST':
-        workflow = request.form.get('workflow', '')
-        action = request.form.get('action')
-        if action in {'build', 'preview'}:
-            preview = workflow
-        elif action == 'run':
-            flash(f"Running workflow: {workflow}")
-    return render_template('index.html', workflow=workflow, preview=preview)
+        mode = request.form.get('mode', 'workflow')
+        if mode == 'util':
+            util_name = request.form.get('util_name', '')
+            params = request.form.get('params', '')
+            file = request.files.get('csv_file')
+            uploaded = None
+            if file and file.filename:
+                tmp_dir = tempfile.gettempdir()
+                filename = os.path.join(tmp_dir, os.path.basename(file.filename))
+                file.save(filename)
+                uploaded = filename
+            cmd = [
+                'python',
+                '-m',
+                f'utils.{util_name}',
+            ]
+            if params:
+                cmd += shlex.split(params)
+            if uploaded:
+                cmd.append(uploaded)
+            env = os.environ.copy()
+            root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+            env['PYTHONPATH'] = env.get('PYTHONPATH', '') + ':' + root_dir
+            proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+            if proc.returncode != 0:
+                util_output = proc.stderr or 'Error running command'
+            else:
+                util_output = proc.stdout
+            args = shlex.split(params)
+            for arg in args:
+                if arg.endswith('.csv') and (not uploaded or arg != uploaded):
+                    path = os.path.abspath(arg)
+                    if os.path.exists(path):
+                        download_name = path
+                        break
+        else:
+            workflow = request.form.get('workflow', '')
+            action = request.form.get('action')
+            if action in {'build', 'preview'}:
+                preview = workflow
+            elif action == 'run':
+                flash(f"Running workflow: {workflow}")
+    return render_template(
+        'index.html',
+        workflow=workflow,
+        preview=preview,
+        utils=utils_list,
+        util_output=util_output,
+        download_name=download_name,
+    )
 
 
 @app.route('/settings', methods=['GET', 'POST'])
@@ -35,3 +102,9 @@ def settings():
         flash('Settings saved.')
         return redirect(url_for('settings'))
     return render_template('settings.html', env_vars=env_vars)
+
+
+@app.route('/download/<path:filename>')
+def download_file(filename: str):
+    """Send a file from the temporary directory."""
+    return send_from_directory(tempfile.gettempdir(), os.path.basename(filename), as_attachment=True)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,8 +11,39 @@
     {% endif %}
   {% endwith %}
 
-  <h2>Build &amp; Run Your Workflow</h2>
+  <h2>Run a Utility</h2>
+  <form method="post" enctype="multipart/form-data" class="mb-4">
+    <input type="hidden" name="mode" value="util">
+    <div class="mb-3">
+      <label class="form-label">Utility</label>
+      <select class="form-select" name="util_name">
+        {% for u in utils %}
+          <option value="{{ u }}">{{ u }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <input class="form-control" type="text" name="params" placeholder="Parameters">
+    </div>
+    <div class="mb-3">
+      <input class="form-control" type="file" name="csv_file">
+    </div>
+    <button class="btn btn-success" type="submit" name="action" value="run_util">Run</button>
+  </form>
+
+  {% if util_output %}
+    <h3>Output</h3>
+    <pre class="bg-light p-3 border">{{ util_output }}</pre>
+  {% endif %}
+  {% if download_name %}
+    <a class="btn btn-primary" href="{{ url_for('download_file', filename=download_name) }}">Download CSV</a>
+  {% endif %}
+
+  <hr>
+
+  <h2>Build My Own Workflow</h2>
   <form method="post" class="mb-3">
+    <input type="hidden" name="mode" value="workflow">
     <div class="mb-3">
       <textarea class="form-control" name="workflow" rows="6" placeholder="Describe what you want to build">{{ workflow }}</textarea>
     </div>


### PR DESCRIPTION
## Summary
- enhance Flask app to run utilities from the `utils` package
- allow optional CSV upload and result download
- add a download route and update index.html with new forms
- document new functionality in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b8e6a4654832daa53676593f5524c