### PR TITLE
Improve utility dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ environment variables.
 
 The homepage now offers two options:
 
-1. **Run a Utility** – select any script from the `utils/` directory and provide
-   its command‑line parameters. If a script requires a CSV input you can upload
+1. **Run a Utility** – choose an available tool by its description and provide
+   the command‑line parameters. If a utility requires a CSV input you can upload
    the file directly in the form. When a utility produces a CSV output a
    download link will be displayed. Plain text output is shown in the page.
 2. **Build My Own Workflow** – describe a workflow in free text. The current

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,14 +22,25 @@ def load_env():
     return dotenv_values(ENV_FILE)
 
 
-def _list_utils() -> list[str]:
-    """Return available utility modules from the utils package."""
+def _list_utils() -> list[tuple[str, str]]:
+    """Return available utilities as ``(name, description)`` tuples."""
     utils_dir = os.path.join(os.path.dirname(__file__), "..", "utils")
-    items = []
-    for name in os.listdir(utils_dir):
-        if name.endswith(".py"):
-            items.append(name[:-3])
-    return sorted(items)
+    items: list[tuple[str, str]] = []
+    for file_name in os.listdir(utils_dir):
+        if not file_name.endswith(".py"):
+            continue
+        base = file_name[:-3]
+        if base == "common":
+            continue
+        desc = base
+        try:
+            module = __import__(f"utils.{base}", fromlist=["__doc__"])
+            if module.__doc__:
+                desc = module.__doc__.strip().splitlines()[0]
+        except Exception:
+            pass
+        items.append((base, desc))
+    return sorted(items, key=lambda x: x[0])
 
 
 @app.route('/', methods=['GET', 'POST'])

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,8 +17,8 @@
     <div class="mb-3">
       <label class="form-label">Utility</label>
       <select class="form-select" name="util_name">
-        {% for u in utils %}
-          <option value="{{ u }}">{{ u }}</option>
+        {% for name, desc in utils %}
+          <option value="{{ name }}">{{ desc }}</option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
## Summary
- filter out utils/common
- use module docstrings for utility names
- show descriptions in the dropdown
- update docs for new UX

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b906360e4832da051b3590ac6bf6f