### PR TITLE
Add help docs page to web app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -115,6 +115,13 @@ def settings():
     return render_template('settings.html', env_vars=env_vars)
 
 
+@app.route('/help')
+def help_page():
+    """Display simple help information about the app and utilities."""
+    utils_list = _list_utils()
+    return render_template('help.html', utils=utils_list)
+
+
 @app.route('/download/<path:filename>')
 def download_file(filename: str):
     """Send a file from the temporary directory."""

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,9 @@
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('settings') }}">Settings</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('help_page') }}">Help</a>
+          </li>
         </ul>
       </div>
     </nav>

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Help &amp; Documentation</h2>
+  <p class="mb-3">This page provides a quick overview of how to use the Dhisana AI Agent web app.</p>
+
+  <h4>Getting Started</h4>
+  <ol>
+    <li>Open the <strong>Settings</strong> page and fill in your API keys.</li>
+    <li>Visit <a href="https://github.com/dhisana-ai/gtm-ai-tools#quick-start-5-minutes" target="_blank">Setup &amp; Run instructions</a> for installing dependencies and launching the app.</li>
+  </ol>
+
+  <h4>Running Utilities</h4>
+  <p>Use the <strong>Run a Utility</strong> section on the homepage to execute one of the available tools. Select a utility, provide parameters and optional CSV input, then click <em>Run</em>.</p>
+  <ul>
+    {% for name, desc in utils %}
+      <li><strong>{{ name }}</strong> – {{ desc }}</li>
+    {% endfor %}
+  </ul>
+
+  <h4>Building Workflows</h4>
+  <p>The <strong>Build My Own Workflow</strong> section lets you describe a workflow in plain text. Currently it previews your text or flashes that the workflow would run.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/help` route to Flask app
- add help page template listing utilities
- link to README quick-start instructions
- include nav link to new help page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b92bc6dc0832d94598aea7d46e038