### PR TITLE
Add MCP server sample utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The homepage now offers two options:
 ## Utility reference
 
 - [OpenAI Sample](docs/utils_usage.md#openai-sample) – example using the OpenAI API.
+- [MCP Tool Sample](docs/utils_usage.md#mcp-tool-sample) – call OpenAI using an MCP server.
 - [Search LinkedIn URLs](docs/utils_usage.md#search-linkedin-urls) – gather profile URLs from Google.
 - [Find Company Info](docs/utils_usage.md#find-company-info) – locate a company's website and LinkedIn page.
 - [Find User by Name and Keywords](docs/utils_usage.md#find-user-by-name-and-keywords) – look up a LinkedIn profile by name.

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -14,6 +14,17 @@ task run:command -- openai_sample "Hello!"
 
 The script prints the text from the `responses.create` call.
 
+## MCP Tool Sample
+
+`mcp_tool_sample.py` sends a prompt to OpenAI using an MCP server. It requires `OPENAI_API_KEY` along with `MCP_SERVER_URL`, `MCP_API_KEY_HEADER_NAME` and `MCP_API_KEY_HEADER_VALUE`. Optionally set `MCP_SERVER_LABEL`.
+
+Run it with:
+
+```bash
+task run:command -- mcp_tool_sample "Ping"
+```
+
+
 ## Search LinkedIn URLs
 
 `linkedin_search_to_csv.py` queries Google through Serper.dev to find LinkedIn profile URLs and writes them to a CSV file. It requires the `SERPER_API_KEY` environment variable.

--- a/tests/test_mcp_tool_sample.py
+++ b/tests/test_mcp_tool_sample.py
@@ -1,0 +1,32 @@
+import sys
+from types import SimpleNamespace
+from utils import mcp_tool_sample as mod
+
+class DummyClient:
+    def __init__(self):
+        self.kwargs = None
+        self.responses = SimpleNamespace(create=self.create)
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        return SimpleNamespace(output_text="hello")
+
+
+def test_mcp_main(monkeypatch, capsys):
+    dummy = DummyClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("MCP_SERVER_LABEL", "label")
+    monkeypatch.setenv("MCP_SERVER_URL", "http://mcp")
+    monkeypatch.setenv("MCP_API_KEY_HEADER_NAME", "X-Key")
+    monkeypatch.setenv("MCP_API_KEY_HEADER_VALUE", "val")
+    monkeypatch.setattr(sys, "argv", ["mcp_tool_sample.py", "hi"])
+
+    mod.main()
+
+    captured = capsys.readouterr()
+    assert "hello" in captured.out
+    tool = dummy.kwargs["tools"][0]
+    assert tool["server_label"] == "label"
+    assert tool["server_url"] == "http://mcp"
+    assert tool["headers"]["X-Key"] == "val"

--- a/utils/mcp_tool_sample.py
+++ b/utils/mcp_tool_sample.py
@@ -1,0 +1,48 @@
+"""Send a prompt through an MCP server using the OpenAI Responses API."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from openai import OpenAI
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Send a prompt to OpenAI with an MCP server tool"
+    )
+    parser.add_argument("prompt", help="Prompt text to send")
+    args = parser.parse_args()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+    server_label = os.getenv("MCP_SERVER_LABEL", "")
+    server_url = os.getenv("MCP_SERVER_URL")
+    header_name = os.getenv("MCP_API_KEY_HEADER_NAME")
+    header_value = os.getenv("MCP_API_KEY_HEADER_VALUE")
+
+    if not (server_url and header_name and header_value):
+        raise RuntimeError("MCP server environment variables are not set")
+
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model="gpt-4.1",
+        input=args.prompt,
+        tools=[
+            {
+                "type": "mcp",
+                "server_label": server_label,
+                "server_url": server_url,
+                "headers": {header_name: header_value},
+                "require_approval": "never",
+            }
+        ],
+        tool_choice="auto",
+    )
+    print(getattr(response, "output_text", ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `mcp_tool_sample.py` utility that sends prompts to OpenAI with an MCP server tool
- document usage of the new script
- link MCP tool sample from README
- test MCP tool sample utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bce0b98b8832d9a00afe73aa70e2a