### PR TITLE
Add Slack webhook utility

### DIFF
--- a/docs/api_keys.md
+++ b/docs/api_keys.md
@@ -26,6 +26,11 @@ This project uses several APIs. Follow the steps below to generate the required 
 2. Navigate to **Settings** &rarr; **Integrations** &rarr; **Private Apps**.
 3. Create a new private app and copy the access token shown.
 
+## Slack Webhook URL
+
+1. Visit <https://api.slack.com/messaging/webhooks> and create an incoming webhook.
+2. Copy the webhook URL displayed.
+
 ## Adding the keys to the environment
 
 Edit the `.env` file in the project root and set each key:
@@ -35,6 +40,7 @@ OPENAI_API_KEY=your_openai_key
 SERPER_API_KEY=your_serper_key
 DHISANA_API_KEY=your_dhisana_key
 HUBSPOT_API_KEY=your_hubspot_key
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
 ```
 
 Save the file. The utilities and the Codex CLI will read these variables when run.

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -185,6 +185,14 @@ task run:command -- hubspot_add_note --id 1234 --note "Followed up via email"
 task run:command -- send_email_smtp recipient@example.com --subject "Hi" --body "Hello"
 ```
 
+### Send Slack Message
+
+`send_slack_message.py` posts a message to Slack using a webhook URL. Set `SLACK_WEBHOOK_URL` in the environment or pass `--webhook`.
+
+```bash
+task run:command -- send_slack_message "Deployment finished"
+```
+
 
 ## OpenAI Codex CLI
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ beautifulsoup4
 flask
 python-dotenv
 aiosmtplib
+requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,4 +51,12 @@ if 'openai' not in sys.modules:
     openai.OpenAI = DummyClient
     sys.modules['openai'] = openai
 
+if 'requests' not in sys.modules:
+    requests = types.ModuleType('requests')
+    def dummy_post(*a, **kw):
+        class Resp: pass
+        return Resp()
+    requests.post = dummy_post
+    sys.modules['requests'] = requests
+
 import pytest

--- a/tests/test_send_slack_message.py
+++ b/tests/test_send_slack_message.py
@@ -1,0 +1,26 @@
+import types
+from utils import send_slack_message as mod
+
+class DummyReq:
+    def __init__(self):
+        self.calls = []
+    def post(self, url, json=None, timeout=None):
+        self.calls.append((url, json, timeout))
+        class Resp: pass
+        return Resp()
+
+def test_send_with_env(monkeypatch):
+    dummy = DummyReq()
+    monkeypatch.setattr(mod, "requests", types.SimpleNamespace(post=dummy.post))
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://env-hook")
+    mod.send_slack_message("hello")
+    assert dummy.calls[0][0] == "http://env-hook"
+    assert dummy.calls[0][1] == {"text": "hello"}
+
+
+def test_skip_without_webhook(monkeypatch):
+    dummy = DummyReq()
+    monkeypatch.setattr(mod, "requests", types.SimpleNamespace(post=dummy.post))
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    mod.send_slack_message("hi")
+    assert dummy.calls == []

--- a/utils/send_slack_message.py
+++ b/utils/send_slack_message.py
@@ -1,0 +1,46 @@
+"""Send a message to Slack via an incoming webhook."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def send_slack_message(message: str, webhook: Optional[str] = None) -> None:
+    """Send ``message`` to Slack if the webhook URL is configured."""
+
+    webhook = webhook or os.getenv("SLACK_WEBHOOK_URL")
+    if not webhook:
+        logger.info("SLACK_WEBHOOK_URL not configured; skipping Slack message")
+        return
+
+    try:
+        requests.post(webhook, json={"text": message}, timeout=5)
+        logger.info("Sent Slack message")
+    except requests.RequestException as exc:
+        logger.error("Failed to send Slack message: %s", exc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Send a message to Slack via webhook"
+    )
+    parser.add_argument("message", help="Message text to send")
+    parser.add_argument(
+        "--webhook",
+        help="Webhook URL (defaults to SLACK_WEBHOOK_URL)"
+    )
+    args = parser.parse_args()
+
+    send_slack_message(args.message, args.webhook)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `send_slack_message` utility and tests
- stub `requests` module in tests
- document Slack webhook usage and environment variable
- mention new utility in usage docs
- include `requests` library in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd31c2e5c832d84ce93860a106dd9