### PR TITLE
Add ZeroBounce email validity utility

### DIFF
--- a/tests/test_check_email_zero_bounce.py
+++ b/tests/test_check_email_zero_bounce.py
@@ -1,0 +1,52 @@
+import asyncio
+from utils import check_email_zero_bounce as mod
+
+
+class DummyResp:
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        return self.data
+
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+        self.get_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url):
+        self.get_calls.append(url)
+        return DummyResp(self.data)
+
+
+def test_valid(monkeypatch):
+    session = DummySession({"status": "valid"})
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("ZERO_BOUNCE_API_KEY", "x")
+    result = asyncio.run(mod.check_email("a@b.com"))
+    assert session.get_calls
+    assert result["confidence"] == "high"
+    assert result["is_valid"] is True
+
+
+def test_invalid(monkeypatch):
+    session = DummySession({"status": "invalid"})
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("ZERO_BOUNCE_API_KEY", "x")
+    result = asyncio.run(mod.check_email("a@b.com"))
+    assert result["confidence"] == "low"
+    assert result["is_valid"] is False

--- a/utils/check_email_zero_bounce.py
+++ b/utils/check_email_zero_bounce.py
@@ -1,0 +1,51 @@
+"""Check e-mail validity using the ZeroBounce API."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from typing import Any, Dict
+
+import aiohttp
+
+
+def _map_status_to_confidence(status: str) -> str:
+    status = status.lower()
+    if status == "valid":
+        return "high"
+    if status in ("catch-all", "unknown"):
+        return "medium"
+    return "low"
+
+
+async def check_email(email: str) -> Dict[str, Any]:
+    """Return ZeroBounce validation result for ``email``."""
+    api_key = os.getenv("ZERO_BOUNCE_API_KEY")
+    if not api_key:
+        raise RuntimeError("ZERO_BOUNCE_API_KEY environment variable is not set")
+
+    url = f"https://api.zerobounce.net/v2/validate?api_key={api_key}&email={email}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            data = await resp.json()
+    confidence = _map_status_to_confidence(data.get("status", ""))
+    return {
+        "email": email,
+        "confidence": confidence,
+        "is_valid": confidence == "high",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check e-mail validity via ZeroBounce")
+    parser.add_argument("email", help="E-mail address to validate")
+    args = parser.parse_args()
+
+    result = asyncio.run(check_email(args.email))
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `check_email_zero_bounce` utility to validate email addresses
- map ZeroBounce status to confidence levels
- add unit tests covering valid and invalid responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd7fe9278832da9946cad9fc66c08