### PR TITLE
Add Findymail contact lookup utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The homepage now offers two options:
 - [Find User by Name and Keywords](docs/utils_usage.md#find-user-by-name-and-keywords) – look up a LinkedIn profile by name.
 - [Find User by Job Title and Company](docs/utils_usage.md#find-user-by-job-title-and-company) – search by title at a company.
 - [Find Users by Name and Keywords](docs/utils_usage.md#find-users-by-name-and-keywords) – process a CSV of names to find profiles.
+- [Find Email and Phone](docs/utils_usage.md#find-email-and-phone) – look up contact details with Findymail.
 - [Push Lead to Dhisana Webhook](docs/utils_usage.md#push-lead-to-dhisana-webhook) – send a lead record to Dhisana.
 - [Push Company to Dhisana Webhook](docs/utils_usage.md#push-company-to-dhisana-webhook) – send a company record to Dhisana.
 - [Get HubSpot Contact](docs/utils_usage.md#get-hubspot-contact) – retrieve a CRM contact.

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -112,6 +112,21 @@ task run:command_local_mapping -- /tmp find_users_by_name_and_keywords \
 The resulting CSV contains `full_name`, `user_linkedin_url` and
 `search_keywords` for each entry.
 
+## Find Email and Phone
+
+`find_contact_with_findymail.py` queries the Findymail API for a person's
+e-mail address and phone number using their full name and company domain.
+Set the `FINDYMAIL_API_KEY` environment variable before running the script.
+
+Run it with the name and domain:
+
+```bash
+task run:command -- find_contact_with_findymail "Jane Doe" example.com
+```
+
+The script prints a JSON object containing `email`, `phone` and the raw
+`contact_info` returned by Findymail.
+
 ## Push Lead to Dhisana Webhook
 
 `push_lead_to_dhisana_webhook.py` sends a lead's details to a Dhisana webhook endpoint. Provide the full name and optionally the LinkedIn URL, email address, tags, and notes. The script uses the `DHISANA_API_KEY` environment variable for authentication. The webhook URL is read from `DHISANA_WEBHOOK_URL` or can be supplied with `--webhook_url`.

--- a/tests/test_find_contact_with_findymail.py
+++ b/tests/test_find_contact_with_findymail.py
@@ -1,0 +1,52 @@
+import asyncio
+import pytest
+from utils import find_contact_with_findymail as mod
+
+
+class DummyResp:
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        return self.data
+
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, headers=None, json=None):
+        self.posts.append((url, json))
+        return DummyResp(self.data)
+
+
+def test_find_email_and_phone(monkeypatch):
+    data = {"contact": {"email": "e@x.com", "phoneNumbers": ["123"]}}
+    session = DummySession(data)
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("FINDYMAIL_API_KEY", "key")
+    result = asyncio.run(mod.find_email_and_phone("John Doe", "example.com"))
+    assert session.posts[0][0].endswith("/search/name")
+    assert result["email"] == "e@x.com"
+    assert result["phone"] == "123"
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("FINDYMAIL_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        asyncio.run(mod.find_email_and_phone("A", "b.com"))
+

--- a/utils/find_contact_with_findymail.py
+++ b/utils/find_contact_with_findymail.py
@@ -1,0 +1,76 @@
+"""Find e-mail and phone number using Findymail."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict
+
+import aiohttp
+
+API_BASE = "https://app.findymail.com/api"
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+async def find_email_and_phone(full_name: str, domain: str) -> Dict[str, Any]:
+    """Return e-mail and phone number for ``full_name`` at ``domain``."""
+    api_key = os.getenv("FINDYMAIL_API_KEY")
+    if not api_key:
+        raise RuntimeError("FINDYMAIL_API_KEY environment variable is not set")
+
+    if not full_name or not domain:
+        return {"email": "", "phone": "", "contact_info": ""}
+
+    url = f"{API_BASE}/search/name"
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    payload = {"name": full_name, "domain": domain}
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, headers=headers, json=payload) as resp:
+            data = await resp.json()
+
+    contact = data.get("contact") or {}
+    email = contact.get("email", "")
+    phone = ""
+    for key in [
+        "phone",
+        "phone_number",
+        "phoneNumber",
+        "phoneNumbers",
+        "phones",
+        "mobile",
+    ]:
+        val = contact.get(key)
+        if isinstance(val, str) and val:
+            phone = val
+            break
+        if isinstance(val, list) and val:
+            phone = val[0]
+            break
+
+    return {
+        "email": email,
+        "phone": phone,
+        "contact_info": json.dumps(contact) if contact else "",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Find a person's e-mail and phone number using Findymail"
+    )
+    parser.add_argument("full_name", help="Person's full name")
+    parser.add_argument("company_domain", help="Company domain")
+    args = parser.parse_args()
+
+    result = asyncio.run(find_email_and_phone(args.full_name, args.company_domain))
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `find_contact_with_findymail.py` for email/phone lookup
- document usage in README and docs/utils_usage
- add tests for new utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd96baa64832da3020dec11600930