### PR TITLE
Add Apollo utilities

### DIFF
--- a/tests/test_apollo_info.py
+++ b/tests/test_apollo_info.py
@@ -1,0 +1,55 @@
+import asyncio
+import pytest
+from utils import apollo_info as mod
+
+class DummyResp:
+    def __init__(self, data):
+        self.data = data
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def json(self):
+        return self.data
+
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+        self.posts = []
+        self.gets = []
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    def post(self, url, headers=None, json=None):
+        self.posts.append((url, json))
+        return DummyResp(self.data)
+    def get(self, url, headers=None):
+        self.gets.append(url)
+        return DummyResp(self.data)
+
+
+def test_get_person_info(monkeypatch):
+    session = DummySession({"person": {"id": "1"}})
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("APOLLO_API_KEY", "x")
+    result = asyncio.run(mod.get_person_info(email="a@b.com"))
+    assert session.posts[0][0].endswith("/people/match")
+    assert session.posts[0][1] == {"email": "a@b.com"}
+    assert result["person"]["id"] == "1"
+
+
+def test_get_company_info(monkeypatch):
+    session = DummySession({"id": "org"})
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("APOLLO_API_KEY", "y")
+    result = asyncio.run(mod.get_company_info(company_url="https://foo.com"))
+    assert session.gets[0].endswith("domain=foo.com")
+    assert result["id"] == "org"
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("APOLLO_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        asyncio.run(mod.get_person_info(email="e@x.com"))

--- a/utils/apollo_info.py
+++ b/utils/apollo_info.py
@@ -1,0 +1,75 @@
+"""Utilities for fetching person and company info from Apollo.io."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from typing import Any, Dict
+
+import aiohttp
+
+from utils.find_company_info import extract_domain
+
+API_BASE = "https://api.apollo.io/api/v1"
+
+
+async def get_person_info(linkedin_url: str = "", email: str = "") -> Dict[str, Any]:
+    """Return person details from Apollo.io using LinkedIn URL or email."""
+    api_key = os.getenv("APOLLO_API_KEY")
+    if not api_key:
+        raise RuntimeError("APOLLO_API_KEY environment variable is not set")
+
+    if not linkedin_url and not email:
+        raise RuntimeError("Provide linkedin_url or email")
+
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
+    payload: Dict[str, Any] = {}
+    if linkedin_url:
+        payload["linkedin_url"] = linkedin_url
+    if email:
+        payload["email"] = email
+
+    async with aiohttp.ClientSession() as session:
+        url = f"{API_BASE}/people/match"
+        async with session.post(url, headers=headers, json=payload) as resp:
+            return await resp.json()
+
+
+async def get_company_info(company_url: str = "", primary_domain: str = "") -> Dict[str, Any]:
+    """Return organization details from Apollo.io using company URL or domain."""
+    api_key = os.getenv("APOLLO_API_KEY")
+    if not api_key:
+        raise RuntimeError("APOLLO_API_KEY environment variable is not set")
+
+    domain = primary_domain or ""
+    if company_url and not domain:
+        domain = extract_domain(company_url)
+    if not domain:
+        raise RuntimeError("Provide company_url or primary_domain")
+
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
+    async with aiohttp.ClientSession() as session:
+        url = f"{API_BASE}/organizations/enrich?domain={domain}"
+        async with session.get(url, headers=headers) as resp:
+            return await resp.json()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch info from Apollo.io")
+    parser.add_argument("--linkedin_url", default="", help="Person LinkedIn URL")
+    parser.add_argument("--email", default="", help="Person email")
+    parser.add_argument("--company_url", default="", help="Company website URL")
+    parser.add_argument("--primary_domain", default="", help="Company domain")
+    args = parser.parse_args()
+
+    if args.linkedin_url or args.email:
+        result = asyncio.run(get_person_info(args.linkedin_url, args.email))
+    else:
+        result = asyncio.run(get_company_info(args.company_url, args.primary_domain))
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `apollo_info.py` utilities to fetch Apollo person and company data
- test Apollo utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdb372b6c832d91f2da42ede24a01