### PR TITLE
Mask env values by default

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dhisana AI Agent</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
   <header class="bg-light border-bottom mb-4">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -15,11 +15,30 @@
   <form method="post">
     {% for key, value in env_vars.items() %}
       <div class="mb-3">
-        <label class="form-label">{{ key }}
-          <input class="form-control" type="text" name="{{ key }}" value="{{ value }}">
-        </label>
+        <label class="form-label" for="{{ key }}">{{ key }}</label>
+        <div class="input-group">
+          <input class="form-control" type="password" id="{{ key }}" name="{{ key }}" value="{{ value }}">
+          <button class="btn btn-outline-secondary toggle-password" type="button" data-target="{{ key }}">
+            <i class="bi bi-eye"></i>
+          </button>
+        </div>
       </div>
     {% endfor %}
     <button class="btn btn-primary" type="submit">Save</button>
   </form>
+
+  <script>
+    document.querySelectorAll('.toggle-password').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var input = document.getElementById(btn.dataset.target);
+        if (input.type === 'password') {
+          input.type = 'text';
+          btn.innerHTML = '<i class="bi bi-eye-slash"></i>';
+        } else {
+          input.type = 'password';
+          btn.innerHTML = '<i class="bi bi-eye"></i>';
+        }
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update base template to load Bootstrap icons
- hide environment values in settings behind password fields
- allow toggling visibility via eye icon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdcc12948832d9646aeb601bd3831