### PR TITLE
Improve UI hints and support webpage extraction CLI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -75,7 +75,10 @@ UTILITY_PARAMETERS = {
         {"name": "properties", "label": "key=value pairs"},
     ],
     "linkedin_search_to_csv": [
-        {"name": "query", "label": "Google query"},
+        {
+            "name": "query",
+            "label": 'Google query (e.g. site:linkedin.com/in "VP Sales")',
+        },
         {"name": "--num", "label": "Number of results"},
     ],
     "mcp_tool_sample": [{"name": "prompt", "label": "Prompt"}],
@@ -94,6 +97,13 @@ UTILITY_PARAMETERS = {
         {"name": "--tags", "label": "Tags"},
         {"name": "--notes", "label": "Notes"},
         {"name": "--webhook_url", "label": "Webhook URL"},
+    ],
+    "extract_from_webpage": [
+        {"name": "url", "label": "Website URL"},
+        {"name": "--lead", "label": "Fetch lead", "type": "boolean"},
+        {"name": "--leads", "label": "Fetch leads", "type": "boolean"},
+        {"name": "--company", "label": "Fetch company", "type": "boolean"},
+        {"name": "--companies", "label": "Fetch companies", "type": "boolean"},
     ],
     "send_email_smtp": [
         {"name": "recipient", "label": "Recipient"},

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -18,7 +18,7 @@
       <label class="form-label">Utility</label>
       <select class="form-select" name="util_name" id="util-select">
         {% for name, desc in utils %}
-          <option value="{{ name }}" {% if name == default_util %}selected{% endif %}>{{ desc }}</option>
+          <option value="{{ name }}" {% if name == default_util %}selected{% endif %}>{{ loop.index }}. {{ desc }}</option>
         {% endfor %}
       </select>
     </div>

--- a/utils/extract_from_webpage.py
+++ b/utils/extract_from_webpage.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import os
 import logging
+import argparse
+import asyncio
 from typing import List, Optional, Tuple, Type
 
 from bs4 import BeautifulSoup
@@ -121,4 +123,44 @@ async def extract_multiple_leads_from_webpage(url: str) -> List[Lead]:
 async def extract_lead_from_webpage(url: str) -> Optional[Lead]:
     leads = await extract_multiple_leads_from_webpage(url)
     return leads[0] if leads else None
+
+
+async def _run_cli(url: str, args: argparse.Namespace) -> None:
+    if args.lead:
+        result = await extract_lead_from_webpage(url)
+        if result:
+            print(result.json(indent=2))
+        return
+    if args.leads:
+        result = await extract_multiple_leads_from_webpage(url)
+        print("[]" if not result else LeadList(leads=result).json(indent=2))
+        return
+    if args.company:
+        result = await extract_comapy_from_webpage(url)
+        if result:
+            print(result.json(indent=2))
+        return
+    if args.companies:
+        result = await extract_multiple_companies_from_webpage(url)
+        print("[]" if not result else CompanyList(companies=result).json(indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract leads or companies from a web page"
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--lead", action="store_true", help="Fetch first lead")
+    group.add_argument("--leads", action="store_true", help="Fetch all leads")
+    group.add_argument("--company", action="store_true", help="Fetch first company")
+    group.add_argument(
+        "--companies", action="store_true", help="Fetch all companies"
+    )
+    parser.add_argument("url", help="Website URL")
+    args = parser.parse_args()
+    asyncio.run(_run_cli(args.url, args))
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- number utility dropdown entries for easier reference
- clarify Google query label with example
- add options for extracting data from a webpage
- implement CLI interface in `extract_from_webpage.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bf55fc578832da312d7303c2e1525