### PR TITLE
Add summarize option to Playwright HTML fetcher

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,8 +30,8 @@ UTILITY_PARAMETERS = {
     "check_email_zero_bounce": [{"name": "email", "label": "E-mail"}],
     "fetch_html_playwright": [
         {"name": "url", "label": "URL"},
-        {"name": "--proxy_url", "label": "Proxy URL"},
-        {"name": "--captcha_key", "label": "2Captcha key"},
+        {"name": "--summarize", "label": "Summarize content", "type": "boolean"},
+        {"name": "--instructions", "label": "Summarize instructions"},
     ],
     "find_a_user_by_name_and_keywords": [
         {"name": "full_name", "label": "Full name"},

--- a/tests/test_fetch_html_playwright.py
+++ b/tests/test_fetch_html_playwright.py
@@ -1,0 +1,51 @@
+import sys
+from types import SimpleNamespace
+from utils import fetch_html_playwright as mod
+
+async def dummy_fetch(url, proxy_url=None, captcha_key=None):
+    dummy_fetch.called = {
+        "url": url,
+        "proxy_url": proxy_url,
+        "captcha_key": captcha_key,
+    }
+    return "<html>text</html>"
+
+def test_main_returns_html(monkeypatch, capsys):
+    monkeypatch.setenv("PROXY_URL", "http://proxy")
+    monkeypatch.setenv("TWO_CAPTCHA_API_KEY", "k")
+    monkeypatch.setattr(mod, "fetch_html", dummy_fetch)
+    monkeypatch.setattr(sys, "argv", ["fetch_html_playwright.py", "http://e.com"])
+    mod.main()
+    captured = capsys.readouterr()
+    assert "<html>text</html>" in captured.out
+    assert dummy_fetch.called["proxy_url"] == "http://proxy"
+    assert dummy_fetch.called["captcha_key"] == "k"
+
+def test_main_with_summary(monkeypatch, capsys):
+    monkeypatch.setenv("PROXY_URL", "http://proxy")
+    monkeypatch.setenv("TWO_CAPTCHA_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(mod, "fetch_html", dummy_fetch)
+
+    class DummyClient:
+        def __init__(self):
+            self.kwargs = None
+            self.responses = SimpleNamespace(create=self.create)
+        def create(self, **kwargs):
+            self.kwargs = kwargs
+            return SimpleNamespace(output_text="summary")
+
+    dummy = DummyClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: dummy)
+    monkeypatch.setattr(sys, "argv", [
+        "fetch_html_playwright.py",
+        "http://e.com",
+        "--summarize",
+        "--instructions",
+        "Summ it",
+    ])
+    mod.main()
+    captured = capsys.readouterr()
+    assert "summary" in captured.out
+    assert "Summ it" in dummy.kwargs["input"]
+


### PR DESCRIPTION
## Summary
- support summarizing HTML output via OpenAI
- read proxy and captcha credentials from environment only
- update flask UI parameter list
- stub additional modules for tests and add new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bf86e4388832d8c0511ce5fa0bbda