### PR TITLE
Add GitHub links and expand vibe coding docs

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,12 @@
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('help_page') }}">Help</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://github.com/dhisana-ai/gtm-ai-tools" target="_blank">GitHub</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://www.dhisana.ai" target="_blank">Signup for 24/7 managed AI Agents</a>
+          </li>
         </ul>
       </div>
     </nav>

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -17,4 +17,20 @@
       <li><strong>{{ name }}</strong> – {{ desc }}</li>
     {% endfor %}
   </ul>
+
+  <h4 id="vibe-coding">Vibe Coding New Workflows</h4>
+  <p>You can create additional utilities with the OpenAI Codex CLI.</p>
+  <ol>
+    <li>Install Node.js 22+ and <code>@openai/codex</code>.</li>
+    <li>Run <code>task add_utility -- my_tool "describe what it should do"</code>.</li>
+    <li>Commit your script and push it to GitHub.</li>
+  </ol>
+  <p>Example ideas:</p>
+  <ul>
+    <li>Find people by job title at a company.</li>
+    <li>Look up people by name and keywords.</li>
+    <li>Scrape a custom website for leads.</li>
+    <li>Use an LLM to research a company.</li>
+  </ul>
+  <p>See the <a href="https://github.com/dhisana-ai/gtm-ai-tools/blob/main/docs/vibe_coding_workflows.md" target="_blank">vibe coding guide</a> for details.</p>
 {% endblock %}

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -12,6 +12,14 @@
   {% endwith %}
 
   <h2>Run a Utility</h2>
+  <p class="lead">
+    Vibe code and add your own GTM workflow in 5 min!
+    <a href="https://github.com/dhisana-ai/gtm-ai-tools/blob/main/docs/vibe_coding_workflows.md" target="_blank">Vibe coding instructions</a>
+  </p>
+  <p>
+    View this project on <a href="https://github.com/dhisana-ai/gtm-ai-tools" target="_blank">GitHub</a>.
+    <a href="https://www.dhisana.ai" target="_blank">Signup</a> and get a 24/7 managed version of this service that runs an AI Agent for you in the cloud with all these workflows and more.
+  </p>
   <form method="post" enctype="multipart/form-data" class="mb-4" id="util-form">
     <input type="hidden" name="mode" value="util">
     <div class="mb-3">

--- a/docs/vibe_coding_workflows.md
+++ b/docs/vibe_coding_workflows.md
@@ -17,3 +17,12 @@ The CLI runs locally, outside the Docker container.
    git commit -am "Add my tool"
    git push origin my-feature
    ```
+
+4. Rebuild the Docker image and start the web app to access your new utility.
+
+## Example workflow ideas
+
+- Find people by job title at a company.
+- Look up people by name and keywords.
+- Scrape a custom website for leads.
+- Use an LLM to research and summarize a company.


### PR DESCRIPTION
## Summary
- link to GitHub repo and Dhisana managed service in navbar
- show links and vibe coding callout on the main page
- expand help page with vibe coding instructions and example ideas
- broaden `docs/vibe_coding_workflows.md` with more details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c5e501c90832daf0bafd6851bfa9f