### PR TITLE
Improve tool display names

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -146,10 +146,15 @@ def load_env():
     return dotenv_values(ENV_FILE)
 
 
-def _list_utils() -> list[tuple[str, str]]:
-    """Return available utilities as ``(name, description)`` tuples."""
+def _format_title(name: str) -> str:
+    """Return a human friendly title from a module name."""
+    return name.replace("_", " ").title()
+
+
+def _list_utils() -> list[dict[str, str]]:
+    """Return available utilities as ``{"name", "title", "desc"}`` dicts."""
     utils_dir = os.path.join(os.path.dirname(__file__), "..", "utils")
-    items: list[tuple[str, str]] = []
+    items: list[dict[str, str]] = []
     for file_name in os.listdir(utils_dir):
         if not file_name.endswith(".py"):
             continue
@@ -163,8 +168,8 @@ def _list_utils() -> list[tuple[str, str]]:
                 desc = module.__doc__.strip().splitlines()[0]
         except Exception:
             pass
-        items.append((base, desc))
-    return sorted(items, key=lambda x: x[0])
+        items.append({"name": base, "title": _format_title(base), "desc": desc})
+    return sorted(items, key=lambda x: x["title"])
 
 
 @app.route('/')

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -13,8 +13,8 @@
   <h4>Running Utilities</h4>
   <p>Use the <strong>Run a Utility</strong> page to execute one of the available tools. Select a utility, provide parameters and optional CSV input, then click <em>Run</em>.</p>
   <ul>
-    {% for name, desc in utils %}
-      <li><strong>{{ name }}</strong> – {{ desc }}</li>
+    {% for util in utils %}
+      <li><strong>{{ util.title }}</strong> – {{ util.desc }}</li>
     {% endfor %}
   </ul>
 

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -22,11 +22,11 @@
   </p>
   <div class="row">
     <div class="col-md-4 mb-4">
-      {% for name, desc in utils %}
-        <div class="card util-card mb-3" data-util="{{ name }}" role="button" style="cursor:pointer;">
+      {% for util in utils %}
+        <div class="card util-card mb-3" data-util="{{ util.name }}" role="button" style="cursor:pointer;">
           <div class="card-body">
-            <h5 class="card-title mb-1">{{ name }}</h5>
-            <p class="card-text small text-muted">{{ desc }}</p>
+            <h5 class="card-title mb-1">{{ util.title }}</h5>
+            <p class="card-text small text-muted">{{ util.desc }}</p>
           </div>
         </div>
       {% endfor %}

--- a/utils/call_openai_llm.py
+++ b/utils/call_openai_llm.py
@@ -1,4 +1,4 @@
-"""Simple utility demonstrating the OpenAI Responses API."""
+"""Use the OpenAI Responses API with a prompt and built-in web search."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from openai import OpenAI
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Send a prompt to OpenAI and print the response"
+        description="Use OpenAI to answer a prompt with web search assistance"
     )
     parser.add_argument("prompt", help="Prompt text to send")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- polish description for `call_openai_llm`
- generate human‑readable titles for utilities
- show titles and descriptions in the web UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c8eb72fbc832d9098842a856a119c