### PR TITLE
Add Node install docs and task

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Follow these steps to spin up the container and run a utility.
 - Ensure Docker is installed. See [Installing Docker](docs/install_docker.md).
 - Obtain API keys and add them to `.env`. See [API key setup](docs/api_keys.md).
 - Install Git and clone this repository. See [Git setup](docs/doc.md).
+- Install Node.js 22+ if you want to generate new utilities. See
+  [Node and Codex installation](docs/install_node.md) or run `task setup:codex`.
 
 
 ## Running the utilities
@@ -133,9 +135,10 @@ See [Using the utilities](docs/utils_usage.md) for examples of running the sampl
 The Codex CLI lets you create new utilities with natural language prompts.
 It runs on your machine, not inside the container. This repository is vibe code ready—just describe what you want in natural language and you can have your custom workflow ready in 5 min.
 
-1. Install **Node.js 22+** and the CLI:
+1. Install **Node.js 22+** and the CLI. Run the helper task or follow the
+   [installation guide](docs/install_node.md):
    ```bash
-   npm install -g @openai/codex
+   task setup:codex
    ```
 2. Generate a utility from the project root. The `task add_utility` command runs
    the Codex CLI in quiet, fully automated mode:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,3 +57,8 @@ tasks:
         fi
         codex -q --approval-mode full-auto --auto-edit "create a utils/${name}.py with the following instructions. add it to app, docs and tools like other tools: $*"
 
+  setup:codex:
+    desc: Install the latest Node.js and Codex CLI
+    cmds:
+      - ./scripts/install-node-codex.sh
+

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -30,7 +30,7 @@
   <h4 id="vibe-coding">Vibe Coding New Workflows</h4>
   <p>You can create additional utilities with the OpenAI Codex CLI.</p>
   <ol>
-    <li>Install Node.js 22+ and <code>@openai/codex</code>.</li>
+    <li>Install Node.js 22+ and <code>@openai/codex</code> (see <code>docs/install_node.md</code> or run <code>task setup:codex</code>).</li>
     <li>Run <code>task add_utility -- search_vp_sales "search for VP of sales and push to Dhisana Webhook"</code>.</li>
     <li>Commit your script and push it to GitHub.</li>
   </ol>

--- a/docs/install_node.md
+++ b/docs/install_node.md
@@ -1,0 +1,38 @@
+# Installing Node.js and the Codex CLI
+
+The Codex CLI requires **Node.js 22** or newer. The steps below use the Node Version Manager (nvm) so they work on Linux or macOS.
+
+## On Windows using WSL
+
+1. Launch your **Ubuntu** (or other Linux) distribution.
+2. Install nvm:
+   ```bash
+   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+   source ~/.nvm/nvm.sh
+   ```
+3. Install the latest Node.js release and the Codex CLI:
+   ```bash
+   nvm install node
+   npm install -g @openai/codex
+   ```
+
+## On Macbook
+
+1. Install nvm:
+   ```bash
+   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+   source ~/.nvm/nvm.sh
+   ```
+2. Install Node.js and the Codex CLI:
+   ```bash
+   nvm install node
+   npm install -g @openai/codex
+   ```
+
+## Using the task command
+
+You can run the following from the project root to perform the same steps automatically:
+
+```bash
+task setup:codex
+```

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -248,11 +248,13 @@ task run:command -- send_slack_message "Deployment finished"
 ## OpenAI Codex CLI
 
 Install the Codex CLI locally to generate new utilities with natural language prompts.
-After installing **Node.js 22+** run:
+Install **Node.js 22+** first (see [install_node.md](install_node.md)) or simply run:
 
 ```bash
-npm install -g @openai/codex
+task setup:codex
 ```
+
+This installs the latest Node.js via `nvm` and the Codex CLI.
 
 You can then invoke it through the `task add_utility` command, which runs Codex
 quietly with automatic approval:

--- a/docs/vibe_coding_workflows.md
+++ b/docs/vibe_coding_workflows.md
@@ -3,9 +3,10 @@
 This project uses the OpenAI Codex CLI to scaffold new utilities.
 The CLI runs locally, outside the Docker container.
 
-1. Install **Node.js 22+** and the CLI:
+1. Install **Node.js 22+** and the CLI. Run the helper task or follow the
+   [install_node.md](install_node.md) guide:
    ```bash
-   npm install -g @openai/codex
+   task setup:codex
    ```
 2. Generate a script from the project root. The `task add_utility` command runs
    the Codex CLI in quiet mode with automatic approval:

--- a/scripts/install-node-codex.sh
+++ b/scripts/install-node-codex.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Install latest Node.js using nvm and then install the Codex CLI
+set -euo pipefail
+
+# Install nvm if not present
+if ! command -v nvm >/dev/null 2>&1; then
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+  # shellcheck source=/dev/null
+  source "$HOME/.nvm/nvm.sh"
+else
+  # shellcheck source=/dev/null
+  source "$HOME/.nvm/nvm.sh"
+fi
+
+# Install and use the latest Node.js
+nvm install node
+nvm use node
+
+# Install the Codex CLI globally
+npm install -g @openai/codex


### PR DESCRIPTION
## Summary
- add instructions for installing Node.js and Codex
- link new install guide from README and update instructions
- patch utils usage, vibe coding docs and help page
- add `setup:codex` task and helper script for installing Node and Codex

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cedb09e38832d91df9a157d7454e3