### PR TITLE
Fix run command examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Common actions:
 3. Run a utility inside the container
 
    ```bash
-   task run:command call_openai_llm "Hello!"
+   task run:command -- call_openai_llm "Hello!"
    ```
 
    The output of the command is saved to `output/run.log` in your working
@@ -95,7 +95,7 @@ To keep files produced by a command, write them to `/workspace` inside the
 container. The `output/` directory on your host maps to this path. For example:
 
 ```bash
-task run:command linkedin_search_to_csv \
+task run:command -- linkedin_search_to_csv \
     "site:linkedin.com/in growth hacker" /workspace/results.csv -n 20
 ```
 


### PR DESCRIPTION
## Summary
- document passing parameters with `--` in README examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ceeb539d8832dbb27e820d3e7bb0b