### PR TITLE
Add image generation utility

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -244,6 +244,20 @@ task run:command -- send_email_smtp recipient@example.com --subject "Hi" --body 
 task run:command -- send_slack_message "Deployment finished"
 ```
 
+## Generate Image with OpenAI
+
+`generate_image.py` creates an image from a text prompt. If you supply an `--image-url` the script edits that picture using the prompt instead of generating a new one. It requires the `OPENAI_API_KEY` environment variable.
+
+```bash
+task run:command -- generate_image "an astronaut riding a horse"
+```
+
+Or edit an existing image:
+
+```bash
+task run:command -- generate_image "add a beach background" --image-url http://example.com/photo.png
+```
+
 
 ## OpenAI Codex CLI
 

--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -1,0 +1,61 @@
+import sys
+from types import SimpleNamespace
+from utils import generate_image as mod
+
+
+class DummyImages:
+    def __init__(self):
+        self.generate_args = None
+        self.edit_args = None
+
+    def generate(self, **kwargs):
+        self.generate_args = kwargs
+        return SimpleNamespace(data=[SimpleNamespace(b64_json="img")])
+
+    def edit(self, **kwargs):
+        self.edit_args = kwargs
+        return SimpleNamespace(data=[SimpleNamespace(b64_json="img")])
+
+
+class DummyClient:
+    def __init__(self):
+        self.images = DummyImages()
+
+
+class DummyResp:
+    def __init__(self, data: bytes):
+        self._data = data
+    def read(self) -> bytes:
+        return self._data
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+def dummy_urlopen(url):
+    dummy_urlopen.called = url
+    return DummyResp(b"content")
+
+
+def test_generate(monkeypatch, capsys):
+    dummy = DummyClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(sys, "argv", ["generate_image.py", "hello"])
+    mod.main()
+    captured = capsys.readouterr()
+    assert "img" in captured.out
+    assert dummy.images.generate_args["prompt"] == "hello"
+
+
+def test_edit(monkeypatch, capsys):
+    dummy = DummyClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: dummy)
+    monkeypatch.setattr(mod.request, "urlopen", dummy_urlopen)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(sys, "argv", ["generate_image.py", "hi", "--image-url", "http://e.com/a.png"])
+    mod.main()
+    captured = capsys.readouterr()
+    assert "img" in captured.out
+    assert dummy.images.edit_args["prompt"] == "hi"
+    assert dummy_urlopen.called == "http://e.com/a.png"

--- a/utils/generate_image.py
+++ b/utils/generate_image.py
@@ -1,0 +1,62 @@
+"""Create an image from a prompt with optional source image.
+
+The script uses the OpenAI images API. Provide a text prompt and optionally
+an image URL to edit. The `OPENAI_API_KEY` environment variable must be set.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+from typing import Optional
+from urllib import request
+from openai import OpenAI
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate an image from a prompt using OpenAI"
+    )
+    parser.add_argument("prompt", help="Text prompt describing the image")
+    parser.add_argument(
+        "--image-url",
+        help="Optional URL of a source image to edit",
+    )
+    args = parser.parse_args()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+    client = OpenAI(api_key=api_key)
+
+    if args.image_url:
+        with request.urlopen(args.image_url) as resp:
+            img_bytes = io.BytesIO(resp.read())
+        img_bytes.name = "image.png"
+        result = client.images.edit(
+            model="gpt-image-1",
+            image=[img_bytes],
+            prompt=args.prompt,
+            size="1024x1024",
+            quality="standard",
+        )
+    else:
+        result = client.images.generate(
+            model="gpt-image-1",
+            prompt=args.prompt,
+            size="1024x1024",
+            quality="standard",
+            response_format="b64_json",
+            n=1,
+        )
+
+    b64 = getattr(result.data[0], "b64_json", None)
+    if b64:
+        print(b64)
+    else:
+        print("No image data returned")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_image.py` for basic GPT image generation or editing
- test new utility
- document new command in `docs/utils_usage.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1f80ed50832da4132de7e988daa8