### PR TITLE
Remove signup text from utilities page

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -16,10 +16,6 @@
     Vibe code and add your own GTM workflow in 5 min!
     <a href="https://github.com/dhisana-ai/gtm-ai-tools/blob/main/docs/vibe_coding_workflows.md" target="_blank">Vibe coding instructions</a>
   </p>
-  <p>
-    View this project on <a href="https://github.com/dhisana-ai/gtm-ai-tools" target="_blank">GitHub</a>.
-    <a href="https://www.dhisana.ai" target="_blank">Signup</a> and get a 24/7 managed version of this service that runs an AI Agent for you in the cloud with all these workflows and more.
-  </p>
   <div class="row">
     <div class="col-md-4 mb-4" style="max-height: 80vh; overflow-y: auto; overflow-x: hidden;">
       {% for util in utils %}


### PR DESCRIPTION
## Summary
- clean up the run utilities page by removing the paragraph advertising the managed service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e5b5c6d7c832d9d7d72a89dd79695