### PR TITLE
Add Slack community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Vibe code and add your own GTM workflow in 5 min! [Vibe coding instructions](doc
 
 View this project on [GitHub](https://github.com/dhisana-ai/gtm-ai-tools). Signup and get a 24/7 managed version of this service that runs an AI Agent for you in the cloud with all these workflows and more.
 
+Join the discussion on our [Slack community channel](https://join.slack.com/t/dhisanaaicommunity/shared_invite/zt-3543qqhoz-XThU6z1VOD21lNf3AI8K3Q).
+
 
 ## Quick Start
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,6 +30,9 @@
           <li class="nav-item">
             <a class="nav-link" href="https://www.dhisana.ai" target="_blank">Signup for 24/7 managed AI Agents</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://join.slack.com/t/dhisanaaicommunity/shared_invite/zt-3543qqhoz-XThU6z1VOD21lNf3AI8K3Q" target="_blank">Join our Slack community</a>
+          </li>
         </ul>
       </div>
     </nav>
@@ -42,14 +45,18 @@
   <footer class="bg-light border-top text-center py-3 mt-4">
     &copy; {{ 2024 }} Dhisana AI
     <div class="small mt-2">
-      <a href="https://github.com/dhisana-ai/gtm-ai-tools" target="_blank" class="text-decoration-none">
-        <i class="bi bi-github"></i> Open Source Repo on GitHub
-      </a>
-      &middot;
-      <a href="https://github.com/dhisana-ai/gtm-ai-tools/blob/main/docs/vibe_coding_workflows.md" target="_blank" class="text-decoration-none">
-        Vibe code your own GTM workflow free in 5 min
-      </a>
-    </div>
-  </footer>
+        <a href="https://github.com/dhisana-ai/gtm-ai-tools" target="_blank" class="text-decoration-none">
+          <i class="bi bi-github"></i> Open Source Repo on GitHub
+        </a>
+        &middot;
+        <a href="https://github.com/dhisana-ai/gtm-ai-tools/blob/main/docs/vibe_coding_workflows.md" target="_blank" class="text-decoration-none">
+          Vibe code your own GTM workflow free in 5 min
+        </a>
+        &middot;
+        <a href="https://join.slack.com/t/dhisanaaicommunity/shared_invite/zt-3543qqhoz-XThU6z1VOD21lNf3AI8K3Q" target="_blank" class="text-decoration-none">
+          Join our Slack community
+        </a>
+      </div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Slack invitation link to README
- link to Slack community in app header and footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ee6f0fc10832d8805352e4eca6fe2