### PR TITLE
Add playbooks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,8 @@ download link will be displayed. Plain text output is shown in the page.
 - [Push Leads to Dhisana](docs/push_leads_to_dhisana.md) – send scraped LinkedIn URLs to Dhisana for enrichment and outreach.
 - [Create Dhisana Webhook](docs/create_dhisana_webhook.md) – configure your webhook and API key.
 
+## Next Workitems
+
+Playbooks to train and test the AI agent:
+- [Common playbooks](docs/playbooks.md)
+

--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -1,0 +1,55 @@
+# Common Playbooks
+
+Following are the common playbooks we need to train the coding agent to generate workflow code reliably. Coding agents will be able to use the following in combination with Dhisana AI service when required to accomplish E2E workflow.
+
+1. Fill in CRM contact details with verified emails, phones, and companies
+2. Find ideal contacts and companies in your total addressable market
+3. Get phone numbers that actually pick up—starting with just an email
+4. Auto-enrich leads from forms and sync to CRM
+5. Send alerts for free trials about to expire and update CRM
+6. Use case studies from prospect websites to customize your outreach
+7. Track when champions at customers change jobs
+8. Watch Reddit for mentions of your brand or competitors
+9. Combine website activity, hiring, and job posts to find hot leads
+10. Track job changes across your entire market
+11. Watch job shifts at your target accounts
+12. Follow company news to find buyers who need you now
+13. Use Google Search to find buying intent signals
+14. Listen to social chatter across LinkedIn, X, Reddit, YouTube
+15. Get notified when your brand is mentioned online
+16. Find customers you share with partners
+17. Tag support tickets by how complex they are
+18. Find and enrich active Slack community members
+19. Automate your monthly or quarterly business reviews
+20. Check if your email domain is properly set up for delivery
+21. Discover top-rated coffee spots with your favorite drinks
+22. Send automatic campaigns for 1-year work anniversaries
+23. Spot interested buyers using TrustRadius activity
+24. Get warm intros to leads through your network
+25. Get financial data on key accounts automatically
+26. Fix CRM data with correct company names and links
+27. Pull competitor names from recorded Gong calls
+28. Generate thousands of custom SEO reports at once
+29. Find and enrich people who liked your LinkedIn posts
+30. Find influencers and get their contact info
+31. Capture attendee details from LinkedIn events
+32. Scrape multiple pages of data fast
+33. Turn Google Maps business listings into lead lists
+34. Extract feature requests from recorded calls
+35. Send automated handwritten-style letters
+36. Find what ads a company is running on Google, FB, LinkedIn
+37. Save screenshots of old pricing or homepage versions
+38. Enrich webinar attendees with verified contact info
+39. Target competitors’ customers using tech stack data
+40. Fix messy parent-child company data in your CRM
+41. Score accounts based on tech and firmographics
+42. Get discount codes for online shopping
+43. Create company profiles with key competitive info
+44. Auto-write LinkedIn connection requests using past posts
+45. Write custom emails using website content
+46. Ask your network for warm intros to top-fit accounts
+47. Find partners and draft outreach emails to them
+48. Find key contacts at companies using just a domain
+49. Enrich school district data with size, location, and test scores
+50. Auto-capture unlimited website screenshots
+


### PR DESCRIPTION
## Summary
- document 50 playbooks used to train and test the coding agent
- link playbooks doc from new **Next Workitems** section in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f1847edc0832db86799cb2e8051d3