### PR TITLE
Add playwright scraper workitem docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,4 +230,5 @@ download link will be displayed. Plain text output is shown in the page.
 
 Playbooks to train and test the AI agent:
 - [Common playbooks](docs/playbooks.md)
+- [Generic Playwright + LLM scraper](docs/generic_scraper_playwright.md)
 

--- a/docs/generic_scraper_playwright.md
+++ b/docs/generic_scraper_playwright.md
@@ -1,0 +1,16 @@
+# Generic Playwright + LLM Scraper
+
+Write a generic scraper that uses **Playwright** for page automation and an **LLM** to parse the HTML into structured content. The scraper should allow parameterizing the page or URL to navigate to and return the extracted data in a JSON format.
+
+Use this approach to automate scraping tasks across multiple websites. Test the agent with the following scenarios:
+
+- Apollo Scraper – Scrape up to 50k Leads
+- Instagram Scraper
+- Google Maps Scraper
+- Google Maps Extractor
+- Google Maps Email Extractor
+- Tweet Scraper V2 (Pay Per Result) – X / Twitter Scraper
+- Instagram Profile Scraper
+- Instagram Reel Scraper
+- Contact Details Scraper
+- Mass LinkedIn Profile Scraper with Email (No Cookies)


### PR DESCRIPTION
## Summary
- document a generic Playwright+LLM scraper idea
- link the doc in the Next Workitems section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f1b2d5b0c832d81b6b4136632edb8