### PR TITLE
Add list of integration tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,4 +231,5 @@ download link will be displayed. Plain text output is shown in the page.
 Playbooks to train and test the AI agent:
 - [Common playbooks](docs/playbooks.md)
 - [Generic Playwright + LLM scraper](docs/generic_scraper_playwright.md)
+- [Integration tools](docs/integration_tools.md) – example services to try when testing new workflows
 

--- a/docs/integration_tools.md
+++ b/docs/integration_tools.md
@@ -1,0 +1,34 @@
+# Integration Tools
+
+The following integrations are available for building and testing GTM workflows. These example services can be used when creating new utilities or verifying existing ones.
+
+- Apollo.io
+- Calendly
+- Clearbit
+- Github
+- Gong
+- Google Docs
+- Google Maps
+- Google Sheets
+- HubSpot
+- Intercom
+- LinkedIn Community
+- Marketo
+- Mixpanel
+- Notion
+- Outreach
+- Postgres
+- Reddit
+- Reply.io
+- Salesforce
+- Sendoso
+- Slack
+- Smartlead.ai
+- Snowflake
+- Stripe
+- Typeform
+- YouTube
+- Zapier
+- ZoomInfo
+
+If you need these grouped by category (for example, CRM, AI or data collection) please let us know.


### PR DESCRIPTION
## Summary
- document various third‑party services for building and testing GTM workflows
- link to the integration tool list from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f21ce3308832dae695bd2a6f77546