### PR TITLE
Fix typo in company extraction utility

### DIFF
--- a/tests/test_extract_from_webpage.py
+++ b/tests/test_extract_from_webpage.py
@@ -1,0 +1,32 @@
+import sys
+import json
+import asyncio
+import types
+
+# Provide a dummy openai module with AsyncOpenAI and OpenAI so imports succeed
+openai_stub = types.SimpleNamespace(
+    AsyncOpenAI=lambda api_key=None: None,
+    OpenAI=lambda api_key=None: None,
+)
+sys.modules['openai'] = openai_stub
+
+from utils import extract_from_webpage as mod
+
+async def fake_multi(url: str):
+    return [mod.Company(organization_name="Acme")]
+
+async def fake_single(url: str):
+    return mod.Company(organization_name="Acme")
+
+def test_extract_company(monkeypatch):
+    monkeypatch.setattr(mod, "extract_multiple_companies_from_webpage", fake_multi)
+    company = asyncio.run(mod.extract_company_from_webpage("http://e.com"))
+    assert company.organization_name == "Acme"
+
+def test_main_company(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "extract_company_from_webpage", fake_single)
+    monkeypatch.setattr(sys, "argv", ["extract_from_webpage.py", "--company", "http://e.com"])
+    mod.main()
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["organization_name"] == "Acme"

--- a/utils/extract_from_webpage.py
+++ b/utils/extract_from_webpage.py
@@ -97,7 +97,8 @@ async def extract_multiple_companies_from_webpage(url: str) -> List[Company]:
     return result.companies
 
 
-async def extract_comapy_from_webpage(url: str) -> Optional[Company]:
+async def extract_company_from_webpage(url: str) -> Optional[Company]:
+    """Return the first company mentioned on ``url`` if any."""
     companies = await extract_multiple_companies_from_webpage(url)
     return companies[0] if companies else None
 
@@ -134,7 +135,7 @@ async def _run_cli(url: str, args: argparse.Namespace) -> None:
         print("[]" if not result else LeadList(leads=result).json(indent=2))
         return
     if args.company:
-        result = await extract_comapy_from_webpage(url)
+        result = await extract_company_from_webpage(url)
         if result:
             print(result.json(indent=2))
         return


### PR DESCRIPTION
## Summary
- fix function name `extract_company_from_webpage`
- update CLI to use the corrected name
- add tests for extracting a company from a webpage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684290fa5b70832aa4aaaba35c566976