### PR TITLE
Add CSV preview grid

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/styles/ag-grid.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/styles/ag-theme-alpine.css">
+  <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/ag-grid-enterprise/dist/ag-grid-enterprise.min.js"></script>
 </head>
 <body class="d-flex flex-column min-vh-100">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,6 +6,9 @@
   <title>Dhisana AI Agent</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/styles/ag-grid.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/styles/ag-theme-alpine.css">
+  <script src="https://cdn.jsdelivr.net/npm/ag-grid-enterprise/dist/ag-grid-enterprise.min.js"></script>
 </head>
 <body class="d-flex flex-column min-vh-100">
   <header class="bg-light border-bottom mb-4">

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -65,7 +65,7 @@
           const gridOptions = { columnDefs, rowData: csvData, pagination: true, paginationPageSize: 20 };
           document.addEventListener('DOMContentLoaded', () => {
             const gridDiv = document.getElementById('csv-grid');
-            new agGrid.Grid(gridDiv, gridOptions);
+            agGrid.createGrid(gridDiv, gridOptions);
           });
         </script>
       {% endif %}

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -56,6 +56,19 @@
       {% if download_name %}
         <a class="btn btn-primary" href="{{ url_for('download_file', filename=download_name) }}">Download CSV</a>
       {% endif %}
+      {% if csv_rows %}
+        <h3 class="mt-4">CSV Preview</h3>
+        <div id="csv-grid" class="ag-theme-alpine" style="height:400px;width:100%;"></div>
+        <script>
+          const csvData = {{ csv_rows|tojson }};
+          const columnDefs = csvData.length ? Object.keys(csvData[0]).map(k => ({ field: k })) : [];
+          const gridOptions = { columnDefs, rowData: csvData, pagination: true, paginationPageSize: 20 };
+          document.addEventListener('DOMContentLoaded', () => {
+            const gridDiv = document.getElementById('csv-grid');
+            new agGrid.Grid(gridDiv, gridOptions);
+          });
+        </script>
+      {% endif %}
       {% if download_name or util_output %}
         <form method="post" action="{{ url_for('push_to_dhisana') }}" class="mt-2">
           <input type="hidden" name="csv_path" value="{{ download_name }}">


### PR DESCRIPTION
## Summary
- show AG Grid in web UI
- display CSV rows from output or uploaded file (max 1000)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e6f50dac832db263d2c9bb35df36