### PR TITLE
Update default util UI behavior

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,7 @@ ENV_FILE = os.path.join(os.path.dirname(__file__), "..", ".env")
 # Optional nicer titles for utilities when displayed in the UI
 UTILITY_TITLES = {
     "call_openai_llm": "OpenAI Tools",
-    "linkedin_search_to_csv": "LinkedIn Search to CSV",
+    "linkedin_search_to_csv": "Find Leads with Google Search",
     "find_a_user_by_name_and_keywords": "Find LinkedIn Profile by Name",
     "find_user_by_job_title": "Find LinkedIn Profile by Job Title",
     "find_users_by_name_and_keywords": "Bulk Find LinkedIn Profiles",
@@ -184,7 +184,13 @@ def _list_utils() -> list[dict[str, str]]:
         except Exception:
             pass
         items.append({"name": base, "title": _format_title(base), "desc": desc})
-    return sorted(items, key=lambda x: x["title"])
+    return sorted(
+        items,
+        key=lambda x: (
+            0 if x["name"] == "linkedin_search_to_csv" else 1,
+            x["title"],
+        ),
+    )
 
 
 @app.route('/')

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -32,6 +32,10 @@
         <input type="hidden" name="mode" value="util">
         <input type="hidden" name="util_name" id="util-name-input" value="{{ default_util }}">
         <div class="mb-3">
+          <h4 id="util-title"></h4>
+          <p id="util-desc" class="text-muted"></p>
+        </div>
+        <div class="mb-3">
           <label class="form-label">Input Mode</label><br>
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="input_mode" id="mode-single" value="single" checked>
@@ -49,15 +53,11 @@
         <button class="btn btn-success" type="submit" name="action" value="run_util">Run</button>
       </form>
 
-      {% if util_output %}
-        <h3>Output</h3>
-        <textarea class="form-control" rows="10" readonly>{{ util_output }}</textarea>
-      {% endif %}
       {% if download_name %}
         <a class="btn btn-primary" href="{{ url_for('download_file', filename=download_name) }}">Download CSV</a>
       {% endif %}
       {% if csv_rows %}
-        <h3 class="mt-4">CSV Preview</h3>
+        <h3 class="mt-4">Input or Output Preview</h3>
         <div id="csv-grid" class="ag-theme-alpine" style="height:400px;width:100%;"></div>
         <script>
           const csvData = {{ csv_rows|tojson }};
@@ -68,6 +68,10 @@
             agGrid.createGrid(gridDiv, gridOptions);
           });
         </script>
+      {% endif %}
+      {% if util_output %}
+        <h3>Output</h3>
+        <textarea class="form-control" rows="10" readonly>{{ util_output }}</textarea>
       {% endif %}
       {% if download_name or util_output %}
         <form method="post" action="{{ url_for('push_to_dhisana') }}" class="mt-2">
@@ -88,6 +92,13 @@
       document.querySelectorAll('.util-card').forEach(card => {
         card.classList.toggle('border-primary', card.dataset.util === name);
       });
+      const card = document.querySelector(`.util-card[data-util="${name}"]`);
+      if (card) {
+        const title = card.querySelector('.card-title')?.textContent || '';
+        const desc = card.querySelector('.card-text')?.textContent || '';
+        document.getElementById('util-title').textContent = title;
+        document.getElementById('util-desc').textContent = desc;
+      }
     }
 
     function renderParams() {


### PR DESCRIPTION
## Summary
- make the `linkedin_search_to_csv` utility appear first in the list
- rename the utility to **Find Leads with Google Search**
- show selected utility title and description in the detail section
- rename preview section to *Input or Output Preview* and move output after the preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f503f61c832db7271513e7dc5a60