### PR TITLE
Make linkedin URL column clickable in grid

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -61,8 +61,30 @@
         <div id="csv-grid" class="ag-theme-alpine" style="height:400px;width:100%;"></div>
         <script>
           const csvData = {{ csv_rows|tojson }};
-          const columnDefs = csvData.length ? Object.keys(csvData[0]).map(k => ({ field: k })) : [];
-          const gridOptions = { columnDefs, rowData: csvData, pagination: true, paginationPageSize: 20 };
+          const columnDefs = csvData.length
+            ? Object.keys(csvData[0]).map(k => {
+                if (k === 'user_linkedin_url') {
+                  return {
+                    field: k,
+                    cellRenderer: params => {
+                      if (!params.value) return '';
+                      const url = params.value.startsWith('http')
+                        ? params.value
+                        : `https://${params.value}`;
+                      return `<a href="${url}" target="_blank" rel="noopener noreferrer">${params.value}</a>`;
+                    }
+                  };
+                }
+                return { field: k };
+              })
+            : [];
+          const gridOptions = {
+            columnDefs,
+            rowData: csvData,
+            pagination: true,
+            paginationPageSize: 20,
+            enableRangeSelection: true
+          };
           document.addEventListener('DOMContentLoaded', () => {
             const gridDiv = document.getElementById('csv-grid');
             agGrid.createGrid(gridDiv, gridOptions);


### PR DESCRIPTION
## Summary
- render `user_linkedin_url` values as links in the AG Grid preview
- enable range selection so grid cells can be copied/pasted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f633465c832d81bdcc6e570dacc3