### PR TITLE
Allow Apollo search by name + domain

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,6 +37,8 @@ UTILITY_PARAMETERS = {
     "apollo_info": [
         {"name": "--linkedin_url", "label": "LinkedIn URL"},
         {"name": "--email", "label": "Email"},
+        {"name": "--full_name", "label": "Full name"},
+        {"name": "--company_domain", "label": "Company domain"},
         {"name": "--company_url", "label": "Company URL"},
         {"name": "--primary_domain", "label": "Company domain"},
     ],

--- a/tests/test_apollo_info.py
+++ b/tests/test_apollo_info.py
@@ -40,6 +40,17 @@ def test_get_person_info(monkeypatch):
     assert result["person"]["id"] == "1"
 
 
+def test_get_person_info_by_name_and_domain(monkeypatch):
+    session = DummySession({"person": {"id": "2"}})
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("APOLLO_API_KEY", "x")
+    result = asyncio.run(
+        mod.get_person_info(full_name="John Doe", company_domain="https://foo.com")
+    )
+    assert session.posts[0][1] == {"name": "John Doe", "domain": "foo.com"}
+    assert result["person"]["id"] == "2"
+
+
 def test_get_company_info(monkeypatch):
     session = DummySession({"id": "org"})
     monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)


### PR DESCRIPTION
## Summary
- expand `get_person_info` to accept full name with company domain
- expose new parameters in CLI and Flask app UI
- test lookup using name & domain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453e77ab04832d8a7ec2f5dbc0b51e