### PR TITLE
Add CSV bulk search for Google leads

### DIFF
--- a/tests/test_linkedin_search_to_csv.py
+++ b/tests/test_linkedin_search_to_csv.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 from utils import linkedin_search_to_csv as mod
 
 async def fake_search(*args, **kwargs):
@@ -14,4 +15,22 @@ def test_linkedin_search_to_csv(tmp_path, monkeypatch):
     content = out_file.read_text().splitlines()
     assert content[0].strip() == "user_linkedin_url"
     assert "https://www.linkedin.com/in/jane" in content[1]
+
+
+def test_linkedin_search_to_csv_from_csv(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    in_file = tmp_path / "in.csv"
+    in_file.write_text("search_query,number_of_responses\nfoo,2\n")
+    out_file = tmp_path / "out.csv"
+    mod.linkedin_search_to_csv_from_csv(in_file, out_file)
+    lines = out_file.read_text().splitlines()
+    assert lines[0].strip() == "user_linkedin_url"
+    assert "linkedin.com/in/jane" in lines[1]
+
+
+def test_linkedin_search_to_csv_from_csv_missing_cols(tmp_path):
+    bad_file = tmp_path / "bad.csv"
+    bad_file.write_text("foo,bar\n1,2\n")
+    with pytest.raises(ValueError):
+        mod.linkedin_search_to_csv_from_csv(bad_file, tmp_path / "out.csv")
 


### PR DESCRIPTION
## Summary
- support running Google LinkedIn search from a CSV file
- update web UI logic to check for `search_query` and `number_of_responses`
- aggregate results into a single CSV
- test new bulk helper function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454297f6c0832dab7b12198b9c0f90