### PR TITLE
Expand Apollo info CSV columns

### DIFF
--- a/tests/test_apollo_info.py
+++ b/tests/test_apollo_info.py
@@ -86,7 +86,7 @@ def test_missing_api_key(monkeypatch):
 
 
 async def fake_get_person_info(linkedin_url="", email="", full_name="", company_domain=""):
-    return {"linkedin_url": linkedin_url, "email": email}
+    return {"user_linkedin_url": linkedin_url, "email": email}
 
 
 def test_apollo_info_from_csv(tmp_path, monkeypatch):
@@ -97,7 +97,8 @@ def test_apollo_info_from_csv(tmp_path, monkeypatch):
     mod.apollo_info_from_csv(in_file, out_file)
     with out_file.open() as fh:
         rows = list(csv.DictReader(fh))
-    assert json.loads(rows[0]["properties"])["email"] == "foo@x.com"
+    assert rows[0]["email"] == "foo@x.com"
+    assert rows[0]["user_linkedin_url"] == "https://linkedin.com/in/foo"
 
 
 def test_apollo_info_from_csv_missing_cols(tmp_path):


### PR DESCRIPTION
## Summary
- spread Apollo properties into separate columns instead of one JSON string
- adjust Apollo CSV test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454ea99c70832d9ed18cab9fb52fb2