### PR TITLE
Fix upload-only utils serialization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,7 +40,9 @@ UTILITY_TITLES = {
 }
 
 # Utilities that only support CSV upload mode
-UPLOAD_ONLY_UTILS = {"find_users_by_name_and_keywords"}
+# Use a list instead of a set so the value can be JSON serialised when passed
+# to templates.
+UPLOAD_ONLY_UTILS = ["find_users_by_name_and_keywords"]
 
 # Mapping of utility parameters for the Run a Utility form. Each utility maps
 # to a list of dictionaries describing the CLI argument name and display label.


### PR DESCRIPTION
## Summary
- fix JSON serialization in Flask template for upload-only utilities by using a list instead of a set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845540e9d14832dafdd7d3ee6a893d8