### PR TITLE
Fix company extraction utility to use image URLs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,6 +37,7 @@ UTILITY_TITLES = {
     "find_user_by_job_title": "Find LinkedIn Profile by Job Title",
     "find_users_by_name_and_keywords": "Bulk Find LinkedIn Profiles",
     "fetch_html_playwright": "Scrape Website HTML (Playwright)",
+    "extract_companies_from_image": "Extract Companies from Image",
 }
 
 # Utilities that only support CSV upload mode
@@ -141,6 +142,9 @@ UTILITY_PARAMETERS = {
         {"name": "--tags", "label": "Tags"},
         {"name": "--notes", "label": "Notes"},
         {"name": "--webhook_url", "label": "Webhook URL"},
+    ],
+    "extract_companies_from_image": [
+        {"name": "image_url", "label": "Image URL"},
     ],
     "extract_from_webpage": [
         {"name": "url", "label": "Website URL"},

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -273,12 +273,12 @@ task run:command -- generate_image "add a beach background" --image-url http://e
 
 ## Extract Companies from Image
 
-`extract_companies_from_image.py` detects company logos in a picture and looks up
-each organization's website, primary domain and LinkedIn page. It requires the
-`OPENAI_API_KEY` and `SERPER_API_KEY` environment variables.
+`extract_companies_from_image.py` detects company logos in an image URL and looks
+up each organization's website, primary domain and LinkedIn page. It requires
+the `OPENAI_API_KEY` and `SERPER_API_KEY` environment variables.
 
 ```bash
-task run:command -- extract_companies_from_image /workspace/logo.png
+task run:command -- extract_companies_from_image http://example.com/logo.png
 ```
 
 

--- a/tests/test_extract_companies_from_image.py
+++ b/tests/test_extract_companies_from_image.py
@@ -4,6 +4,25 @@ from types import SimpleNamespace
 import asyncio
 from utils import extract_companies_from_image as mod
 
+
+class DummyResp:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def dummy_urlopen(url):
+    dummy_urlopen.called = url
+    return DummyResp(b"img")
+
 class DummyClient:
     def __init__(self):
         self.kwargs = None
@@ -24,16 +43,15 @@ async def fake_details(name, location=None):
 def test_main(monkeypatch, tmp_path, capsys):
     dummy = DummyClient()
     monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: dummy)
+    monkeypatch.setattr(mod.request, "urlopen", dummy_urlopen)
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     monkeypatch.setattr(mod.find_company_info, "find_company_details", fake_details)
 
-    img = tmp_path / "logo.png"
-    img.write_bytes(b"img")
-
-    monkeypatch.setattr(sys, "argv", ["extract_companies_from_image.py", str(img)])
+    monkeypatch.setattr(sys, "argv", ["extract_companies_from_image.py", "http://e.com/logo.png"])
     mod.main()
     captured = capsys.readouterr()
     data = json.loads(captured.out)
     assert data[0]["company_name"] == "Acme"
     assert data[0]["company_domain"] == "acme.com"
+    assert dummy_urlopen.called == "http://e.com/logo.png"
     assert "input" in dummy.kwargs


### PR DESCRIPTION
## Summary
- handle image URLs in `extract_companies_from_image`
- expose the new parameter in the web app
- update docs and tests for URL based usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684563b47094832db606d33270dd0106