### PR TITLE
Update generate_image to use responses API

### DIFF
--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -5,21 +5,36 @@ from utils import generate_image as mod
 
 class DummyImages:
     def __init__(self):
-        self.generate_args = None
         self.edit_args = None
 
     def generate(self, **kwargs):
-        self.generate_args = kwargs
-        return SimpleNamespace(data=[SimpleNamespace(b64_json="img")])
+        raise AssertionError("images.generate should not be called")
 
     def edit(self, **kwargs):
         self.edit_args = kwargs
         return SimpleNamespace(data=[SimpleNamespace(b64_json="img")])
 
 
+class DummyResponses:
+    def __init__(self):
+        self.create_args = None
+
+    def create(self, **kwargs):
+        self.create_args = kwargs
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="image_generation_call",
+                    result="img",
+                )
+            ]
+        )
+
+
 class DummyClient:
     def __init__(self):
         self.images = DummyImages()
+        self.responses = DummyResponses()
 
 
 class DummyResp:
@@ -45,7 +60,7 @@ def test_generate(monkeypatch, capsys):
     mod.main()
     captured = capsys.readouterr()
     assert "img" in captured.out
-    assert dummy.images.generate_args["prompt"] == "hello"
+    assert dummy.responses.create_args["input"] == "hello"
 
 
 def test_edit(monkeypatch, capsys):

--- a/utils/generate_image.py
+++ b/utils/generate_image.py
@@ -1,7 +1,8 @@
 """Create an image from a prompt with optional source image.
 
-The script uses the OpenAI images API. Provide a text prompt and optionally
-an image URL to edit. The `OPENAI_API_KEY` environment variable must be set.
+The script uses the OpenAI responses API for generation and the images API for
+editing. Provide a text prompt and optionally an image URL to edit. The
+`OPENAI_API_KEY` environment variable must be set.
 """
 from __future__ import annotations
 
@@ -11,6 +12,7 @@ import os
 from typing import Optional
 from urllib import request
 from openai import OpenAI
+from utils import common
 
 
 def main() -> None:
@@ -43,17 +45,20 @@ def main() -> None:
             response_format="b64_json",
             n=1,
         )
+        b64 = getattr(result.data[0], "b64_json", None)
     else:
-        result = client.images.generate(
-            model="gpt-image-1",
-            prompt=args.prompt,
-            size="1024x1024",
-            quality="standard",
-            response_format="b64_json",
-            n=1,
+        response = client.responses.create(
+            model=common.get_openai_model(),
+            input=args.prompt,
+            tools=[{"type": "image_generation"}],
         )
+        image_data = [
+            output.result
+            for output in getattr(response, "output", [])
+            if getattr(output, "type", "") == "image_generation_call"
+        ]
+        b64 = image_data[0] if image_data else None
 
-    b64 = getattr(result.data[0], "b64_json", None)
     if b64:
         print(b64)
     else:


### PR DESCRIPTION
## Summary
- replace deprecated `images.generate` with `responses.create`
- adjust tests for new OpenAI API usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b892c624832db34f84d4b328ecb9