### PR TITLE
Use responses API for image editing

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -259,7 +259,7 @@ task run:command -- send_slack_message "Deployment finished"
 
 ## Generate Image with OpenAI
 
-`generate_image.py` creates an image from a text prompt. If you supply an `--image-url` the script edits that picture using the prompt instead of generating a new one. It requires the `OPENAI_API_KEY` environment variable.
+`generate_image.py` creates an image from a text prompt. If you supply an `--image-url` the script sends the image along with the prompt to the OpenAI responses API for editing instead of calling the legacy `images.edit` endpoint. It requires the `OPENAI_API_KEY` environment variable.
 
 ```bash
 task run:command -- generate_image "an astronaut riding a horse"

--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -72,5 +72,7 @@ def test_edit(monkeypatch, capsys):
     mod.main()
     captured = capsys.readouterr()
     assert "img" in captured.out
-    assert dummy.images.edit_args["prompt"] == "hi"
+    inp = dummy.responses.create_args["input"]
+    assert inp[0]["content"][0]["text"] == "hi"
+    assert dummy.images.edit_args is None
     assert dummy_urlopen.called == "http://e.com/a.png"


### PR DESCRIPTION
## Summary
- refactor `generate_image.py` to edit images through `client.responses.create`
- update tests for new behaviour
- clarify documentation for editing images using the responses API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bac1b970832dbffdbe6e6d9a1b66