### PR TITLE
Extend OpenAI tool CSV workflow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,6 +13,7 @@ from utils import (
     apollo_info,
     check_email_zero_bounce,
     find_users_by_name_and_keywords,
+    call_openai_llm,
 )
 from pathlib import Path
 from flask import (
@@ -311,6 +312,21 @@ def run_utility():
                 )
                 try:
                     check_email_zero_bounce.check_emails_from_csv(uploaded, out_path)
+                    download_name = out_path
+                    csv_path_for_grid = out_path
+                    util_output = None
+                except Exception as exc:
+                    util_output = f'Error: {exc}'
+                    download_name = None
+                    csv_path_for_grid = None
+            elif util_name == 'call_openai_llm':
+                out_path = os.path.join(
+                    tempfile.gettempdir(),
+                    os.path.basename(uploaded) + '.out.csv',
+                )
+                prompt_text = request.form.get('prompt', '')
+                try:
+                    call_openai_llm.call_openai_llm_from_csv(uploaded, out_path, prompt_text)
                     download_name = out_path
                     csv_path_for_grid = out_path
                     util_output = None

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -183,7 +183,8 @@
         }
         const mode = isUploadOnly ? 'file' : document.querySelector('input[name="input_mode"]:checked').value;
         document.getElementById('file-container').style.display = mode === 'file' ? '' : 'none';
-        document.getElementById('params-container').style.display = mode === 'file' ? 'none' : '';
+        const paramsVisible = !(mode === 'file' && util !== 'call_openai_llm');
+        document.getElementById('params-container').style.display = paramsVisible ? '' : 'none';
       }
     document.querySelectorAll('.util-card').forEach(card => {
         card.addEventListener('click', () => {

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -14,6 +14,11 @@ task run:command -- call_openai_llm "Hello!"
 
 The script prints the text from the `responses.create` call.
 
+When running the tool on a CSV file through the web interface, provide a
+prompt in addition to the uploaded file. The prompt is concatenated with each
+row from the CSV and the responses are written to a new `llm_output` column in
+the output file.
+
 ## MCP Tool Sample
 
 `mcp_tool_sample.py` sends a prompt to OpenAI using an MCP server. It requires `OPENAI_API_KEY` along with `MCP_SERVER_URL`, `MCP_API_KEY_HEADER_NAME` and `MCP_API_KEY_HEADER_VALUE`. Optionally set `MCP_SERVER_LABEL`. The OpenAI model can also be set with `OPENAI_MODEL_NAME`.

--- a/tests/test_call_openai_llm.py
+++ b/tests/test_call_openai_llm.py
@@ -29,3 +29,19 @@ def test_model_env(monkeypatch):
     mod.main()
     assert dummy.kwargs["model"] == "gpt-test"
 
+
+def test_from_csv(tmp_path, monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(mod, "OpenAI", lambda api_key=None: dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    in_file = tmp_path / "in.csv"
+    with in_file.open("w", newline="") as fh:
+        writer = mod.csv.DictWriter(fh, fieldnames=["name"])
+        writer.writeheader()
+        writer.writerow({"name": "Bob"})
+    out_file = tmp_path / "out.csv"
+    mod.call_openai_llm_from_csv(in_file, out_file, "Hello ")
+    with out_file.open(newline="") as fh:
+        rows = list(mod.csv.DictReader(fh))
+    assert rows[0]["llm_output"] == "hi"
+

--- a/utils/call_openai_llm.py
+++ b/utils/call_openai_llm.py
@@ -9,8 +9,54 @@ import argparse
 import os
 
 from utils import common
+import csv
+from pathlib import Path
 
 from openai import OpenAI
+
+
+def _call_openai(prompt: str) -> str:
+    """Return the LLM response text for ``prompt``."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model=common.get_openai_model(),
+        input=prompt,
+        tools=[{"type": "web_search_preview"}],
+    )
+    return response.output_text
+
+
+def call_openai_llm_from_csv(
+    input_file: str | Path, output_file: str | Path, prompt: str
+) -> None:
+    """Run the LLM with ``prompt`` + each CSV row and write results."""
+
+    in_path = Path(input_file)
+    out_path = Path(output_file)
+
+    with in_path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+
+    out_fields = fieldnames + ["llm_output"]
+    processed: list[dict[str, str]] = []
+    for row in rows:
+        row_prompt = f"{prompt}{str(row)}"
+        result = _call_openai(row_prompt)
+        row["llm_output"] = result
+        processed.append(row)
+
+    with out_path.open("w", newline="", encoding="utf-8") as out_fh:
+        writer = csv.DictWriter(out_fh, fieldnames=out_fields)
+        writer.writeheader()
+        for row in processed:
+            writer.writerow(row)
 
 
 def main() -> None:
@@ -20,17 +66,7 @@ def main() -> None:
     parser.add_argument("prompt", help="Prompt text to send")
     args = parser.parse_args()
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
-
-    client = OpenAI(api_key=api_key)
-    response = client.responses.create(
-        model=common.get_openai_model(),
-        input=args.prompt,
-        tools=[{"type": "web_search_preview"}]
-    )
-    print(response.output_text)
+    print(_call_openai(args.prompt))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow running `call_openai_llm` over a CSV
- keep the prompt field visible when uploading an input list
- add CSV processing branch for OpenAI tool in the Flask app
- document new CSV behaviour
- test new helper

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bf881394832d8279493265b65390