### PR TITLE
Add structured lead data to LinkedIn search

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -62,7 +62,7 @@ The script prints a JSON object containing `company_website`, `company_domain` a
 
 ## Find User by Name and Keywords
 
-`find_a_user_by_name_and_keywords.py` searches Google via Serper.dev for a person's LinkedIn profile. Provide the person's full name and optional additional keywords. The script outputs a JSON object containing the full name, the LinkedIn profile URL and the search keywords used.
+`find_a_user_by_name_and_keywords.py` searches Google via Serper.dev for a person's LinkedIn profile. Provide the person's full name and optional additional keywords. The script outputs a JSON object with lead details parsed from the search results, including the LinkedIn profile URL.
 The profile URL is normalized to the `https://www.linkedin.com/in/<id>` format.
 
 Run it with a name and keywords:
@@ -94,8 +94,9 @@ The script prints the resulting JSON to stdout.
 
 `find_users_by_name_and_keywords.py` reads a CSV containing `full_name` and
 `search_keywords` columns. For each row it looks up the person's LinkedIn profile
-using Google search through Serper.dev and writes the results to a new CSV file.
-All profile URLs in the output are normalized to the `https://www.linkedin.com/in/<id>` form.
+using Google search through Serper.dev. The resulting CSV contains lead details
+extracted from the search results (name, title, location, followers, summary) and
+the normalized `user_linkedin_url`.
 
 Run it with an input and output file. When using the Docker based `task` command
 the paths should point inside the container (the local `output/` directory is
@@ -114,8 +115,10 @@ task run:command_local_mapping -- /tmp find_users_by_name_and_keywords \
     /tmp/input.csv /tmp/output.csv
 ```
 
-The resulting CSV contains `full_name`, `user_linkedin_url` and
-`search_keywords` for each entry.
+The resulting CSV includes columns for the parsed lead details
+(`first_name`, `last_name`, `job_title`, `follower_count`, `lead_location`,
+`summary_about_lead`) alongside the normalized `user_linkedin_url` and
+`search_keywords`.
 
 ## Find Email and Phone
 

--- a/tests/test_find_a_user.py
+++ b/tests/test_find_a_user.py
@@ -2,10 +2,21 @@ import asyncio
 from utils import find_a_user_by_name_and_keywords as mod
 
 async def fake_search(*args, **kwargs):
-    return [{"link": "https://www.linkedin.com/in/john-doe"}]
+    return [
+        {
+            "link": "https://www.linkedin.com/in/john-doe",
+            "title": "John Doe - CEO",
+            "snippet": "1k followers New York",
+        }
+    ]
+
+async def fake_structured(text: str):
+    return mod.LeadSearchResult(first_name="John", last_name="Doe")
 
 def test_find_user_linkedin_url(monkeypatch):
     monkeypatch.setattr(mod, "search_google_serper", fake_search)
-    url = asyncio.run(mod.find_user_linkedin_url("John Doe"))
-    assert url == "https://www.linkedin.com/in/john-doe"
+    monkeypatch.setattr(mod, "get_structured_output", fake_structured)
+    data = asyncio.run(mod.find_user_linkedin_url("John Doe"))
+    assert data["user_linkedin_url"] == "https://www.linkedin.com/in/john-doe"
+    assert data["first_name"] == "John"
 

--- a/tests/test_find_users.py
+++ b/tests/test_find_users.py
@@ -3,7 +3,16 @@ from pathlib import Path
 from utils import find_users_by_name_and_keywords as mod
 
 async def fake_find(full_name: str, search_keywords: str = ""):
-    return f"https://www.linkedin.com/in/{full_name.lower().replace(' ', '')}"
+    return {
+        "full_name": full_name,
+        "user_linkedin_url": f"https://www.linkedin.com/in/{full_name.lower().replace(' ', '')}",
+        "first_name": full_name.split()[0],
+        "last_name": full_name.split()[-1],
+        "job_title": "CEO",
+        "follower_count": "",
+        "lead_location": "",
+        "summary_about_lead": "",
+    }
 
 def test_find_users(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "find_user_linkedin_url", fake_find)
@@ -16,4 +25,5 @@ def test_find_users(tmp_path, monkeypatch):
     mod.find_users(input_file, output_file)
     rows = list(csv.DictReader(output_file.open()))
     assert rows[0]["user_linkedin_url"] == "https://www.linkedin.com/in/johndoe"
+    assert rows[0]["first_name"] == "John"
 

--- a/utils/find_a_user_by_name_and_keywords.py
+++ b/utils/find_a_user_by_name_and_keywords.py
@@ -11,15 +11,46 @@ from typing import Optional
 from urllib.parse import urlparse, urlunparse
 
 from utils.common import search_google_serper, extract_user_linkedin_page
+from utils.extract_from_webpage import _get_structured_data_internal
+
+try:
+    from pydantic import BaseModel
+except ImportError:  # pragma: no cover - tests use stub
+    from pydantic_stub import BaseModel
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-async def find_user_linkedin_url(full_name: str, search_keywords: str = "") -> str:
-    """Return the LinkedIn profile URL for a person using Google search."""
+
+class LeadSearchResult(BaseModel):
+    first_name: str = ""
+    last_name: str = ""
+    full_name: str = ""
+    job_title: str = ""
+    follower_count: str = ""
+    lead_location: str = ""
+    summary_about_lead: str = ""
+    user_linkedin_url: str = ""
+
+
+async def get_structured_output(text: str) -> LeadSearchResult:
+    """Parse ``text`` into ``LeadSearchResult`` using OpenAI."""
+
+    prompt = (
+        "Extract lead details from the text below.\n"
+        f"Return JSON matching this schema:\n{json.dumps(LeadSearchResult.model_json_schema(), indent=2)}\n\n"
+        f"Text:\n{text}"
+    )
+    result, status = await _get_structured_data_internal(prompt, LeadSearchResult)
+    if status != "SUCCESS" or result is None:
+        return LeadSearchResult()
+    return result
+
+async def find_user_linkedin_url(full_name: str, search_keywords: str = "") -> dict:
+    """Return lead info including the LinkedIn profile URL using Google search."""
 
     if not full_name:
-        return ""
+        return json.loads(LeadSearchResult().model_dump_json())
 
     query = f'site:linkedin.com/in "{full_name}"'
     if search_keywords:
@@ -28,14 +59,19 @@ async def find_user_linkedin_url(full_name: str, search_keywords: str = "") -> s
     logger.info("Querying Google: %s", query)
     results = await search_google_serper(query, 3)
     for item in results:
+        text = " ".join(
+            [item.get("title", ""), item.get("subtitle", ""), item.get("snippet", "")]
+        ).strip()
+        structured = await get_structured_output(text)
         link = item.get("link", "")
         if not link:
             continue
         parsed = urlparse(link)
         if "linkedin.com/in" in (parsed.netloc + parsed.path):
-            return extract_user_linkedin_page(link)
+            structured.user_linkedin_url = extract_user_linkedin_page(link)
+            return json.loads(structured.model_dump_json())
     logger.info("LinkedIn profile not found")
-    return ""
+    return json.loads(LeadSearchResult().model_dump_json())
 
 
 def main() -> None:
@@ -53,13 +89,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    url = asyncio.run(find_user_linkedin_url(args.full_name, args.search_keywords))
-    result = {
-        "full_name": args.full_name,
-        "user_linkedin_url": url,
-        "search_keywords": args.search_keywords,
-    }
-    print(json.dumps(result, indent=2))
+    info = asyncio.run(find_user_linkedin_url(args.full_name, args.search_keywords))
+    info["search_keywords"] = args.search_keywords
+    if not info.get("full_name"):
+        info["full_name"] = args.full_name
+    print(json.dumps(info, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enrich LinkedIn search by parsing search result text with OpenAI
- include new lead fields when looking up single users
- write these fields when processing CSV batches
- document updated behaviour
- update relevant tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d5a49f64832da5e4f59fded2f60a