### PR TITLE
Enhance LinkedIn search CSV output

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -32,8 +32,8 @@ task run:command -- mcp_tool_sample "Ping"
 
 ## Search LinkedIn URLs
 
-`linkedin_search_to_csv.py` queries Google through Serper.dev to find LinkedIn profile URLs and writes them to a CSV file. It requires the `SERPER_API_KEY` environment variable.
-All LinkedIn URLs in the output are normalized to the `https://www.linkedin.com/in/<id>` format.
+`linkedin_search_to_csv.py` queries Google through Serper.dev to find LinkedIn profile URLs and extracts basic lead details from the search snippets. The results are written to a CSV file and require the `SERPER_API_KEY` environment variable.
+All LinkedIn URLs in the output are normalized to the `https://www.linkedin.com/in/<id>` format and each row includes the parsed lead information.
 
 Example usage fetching 20 results:
 

--- a/tests/test_linkedin_search_to_csv.py
+++ b/tests/test_linkedin_search_to_csv.py
@@ -1,31 +1,37 @@
 from pathlib import Path
+import csv
 import pytest
 from utils import linkedin_search_to_csv as mod
 
 async def fake_search(*args, **kwargs):
     return [
-        {"link": "https://www.linkedin.com/in/jane"},
+        {"link": "https://www.linkedin.com/in/jane", "title": "Jane Doe", "snippet": "CEO"},
         {"link": "https://example.com"},
     ]
 
+async def fake_structured(text: str):
+    return mod.LeadSearchResult(first_name="Jane", last_name="Doe")
+
 def test_linkedin_search_to_csv(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    monkeypatch.setattr(mod, "get_structured_output", fake_structured)
     out_file = tmp_path / "out.csv"
     mod.linkedin_search_to_csv("query", 2, str(out_file))
-    content = out_file.read_text().splitlines()
-    assert content[0].strip() == "user_linkedin_url"
-    assert "https://www.linkedin.com/in/jane" in content[1]
+    rows = list(csv.DictReader(out_file.open()))
+    assert rows[0]["user_linkedin_url"] == "https://www.linkedin.com/in/jane"
+    assert rows[0]["first_name"] == "Jane"
 
 
 def test_linkedin_search_to_csv_from_csv(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "search_google_serper", fake_search)
+    monkeypatch.setattr(mod, "get_structured_output", fake_structured)
     in_file = tmp_path / "in.csv"
     in_file.write_text("search_query,number_of_responses\nfoo,2\n")
     out_file = tmp_path / "out.csv"
     mod.linkedin_search_to_csv_from_csv(in_file, out_file)
-    lines = out_file.read_text().splitlines()
-    assert lines[0].strip() == "user_linkedin_url"
-    assert "linkedin.com/in/jane" in lines[1]
+    rows = list(csv.DictReader(out_file.open()))
+    assert rows[0]["user_linkedin_url"].endswith("/jane")
+    assert rows[0]["first_name"] == "Jane"
 
 
 def test_linkedin_search_to_csv_from_csv_missing_cols(tmp_path):


### PR DESCRIPTION
## Summary
- expand `linkedin_search_to_csv` to parse lead details
- update CSV aggregation logic
- adjust tests for new behaviour
- document updated usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e495a0f4832dae36e94f89e2caa6