### PR TITLE
Improve follower_count type and reorder CSV display

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -402,10 +402,23 @@ def run_utility():
             import csv
             with open(csv_path_for_grid, newline='', encoding='utf-8-sig') as fh:
                 reader = csv.DictReader(fh)
+                display_order = [
+                    "full_name",
+                    "user_linkedin_url",
+                    "job_title",
+                    "email",
+                ]
                 for i, row in enumerate(reader):
                     if i >= 1000:
                         break
-                    csv_rows.append(row)
+                    ordered = {}
+                    for key in display_order:
+                        if key in row:
+                            ordered[key] = row[key]
+                    for key, value in row.items():
+                        if key not in ordered:
+                            ordered[key] = value
+                    csv_rows.append(ordered)
         except Exception:
             csv_rows = []
     return render_template(

--- a/tests/test_find_users.py
+++ b/tests/test_find_users.py
@@ -9,7 +9,7 @@ async def fake_find(full_name: str, search_keywords: str = ""):
         "first_name": full_name.split()[0],
         "last_name": full_name.split()[-1],
         "job_title": "CEO",
-        "follower_count": "",
+        "follower_count": 0,
         "lead_location": "",
         "summary_about_lead": "",
     }

--- a/utils/find_a_user_by_name_and_keywords.py
+++ b/utils/find_a_user_by_name_and_keywords.py
@@ -27,7 +27,7 @@ class LeadSearchResult(BaseModel):
     last_name: str = ""
     full_name: str = ""
     job_title: str = ""
-    follower_count: str = ""
+    follower_count: int = 0
     lead_location: str = ""
     summary_about_lead: str = ""
     user_linkedin_url: str = ""


### PR DESCRIPTION
## Summary
- parse follower count as integer in `LeadSearchResult`
- adjust unit test stubs for new type
- display CSV preview columns starting with `full_name`, `user_linkedin_url`, `job_title`, `email`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e86dd9d4832db293302d51272e89