### PR TITLE
Ensure grid columns use consistent order

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,6 +31,14 @@ app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET", "dev")
 ENV_FILE = os.path.join(os.path.dirname(__file__), "..", ".env")
 
+# Preferred column order when displaying CSV data in the grid
+DISPLAY_ORDER = [
+    "full_name",
+    "user_linkedin_url",
+    "job_title",
+    "email",
+]
+
 # Optional nicer titles for utilities when displayed in the UI
 UTILITY_TITLES = {
     "call_openai_llm": "OpenAI Tools",
@@ -402,12 +410,7 @@ def run_utility():
             import csv
             with open(csv_path_for_grid, newline='', encoding='utf-8-sig') as fh:
                 reader = csv.DictReader(fh)
-                display_order = [
-                    "full_name",
-                    "user_linkedin_url",
-                    "job_title",
-                    "email",
-                ]
+                display_order = DISPLAY_ORDER
                 for i, row in enumerate(reader):
                     if i >= 1000:
                         break

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -73,23 +73,32 @@
           <div id="csv-grid" class="ag-theme-alpine" style="height:400px;width:100%;"></div>
           <script>
             const csvData = {{ csv_rows|tojson }};
-            const columnDefs = csvData.length
-              ? Object.keys(csvData[0]).map(k => {
-                  if (k === 'user_linkedin_url') {
-                    return {
-                      field: k,
-                      cellRenderer: params => {
-                        if (!params.value) return '';
-                        const url = params.value.startsWith('http')
-                          ? params.value
-                          : `https://${params.value}`;
-                        return `<a href="${url}" target="_blank" rel="noopener noreferrer">${params.value}</a>`;
-                      }
-                    };
+            const preferredOrder = [
+              'full_name',
+              'user_linkedin_url',
+              'job_title',
+              'email'
+            ];
+            const allKeys = csvData.length ? Object.keys(csvData[0]) : [];
+            const orderedKeys = [
+              ...preferredOrder.filter(k => allKeys.includes(k)),
+              ...allKeys.filter(k => !preferredOrder.includes(k))
+            ];
+            const columnDefs = orderedKeys.map(k => {
+              if (k === 'user_linkedin_url') {
+                return {
+                  field: k,
+                  cellRenderer: params => {
+                    if (!params.value) return '';
+                    const url = params.value.startsWith('http')
+                      ? params.value
+                      : `https://${params.value}`;
+                    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${params.value}</a>`;
                   }
-                  return { field: k };
-                })
-              : [];
+                };
+              }
+              return { field: k };
+            });
             const gridOptions = {
               columnDefs,
               rowData: csvData,


### PR DESCRIPTION
## Summary
- define a `DISPLAY_ORDER` constant for grids
- reuse constant when reading CSVs for display
- keep lead grid columns ordered on the frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848eb22c2e0832db63b3ffc73cc1cb4