### PR TITLE
Add auto CSV chaining between utilities

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -28,6 +28,15 @@
       {% endfor %}
     </div>
     <div class="col-md-8">
+      {% if prev_csv %}
+      <div class="alert alert-secondary d-flex align-items-center mb-3">
+        <div class="flex-grow-1">Using previous CSV: {{ prev_csv }}</div>
+        <form method="post" class="ms-2">
+          <input type="hidden" name="action" value="clear_csv">
+          <button class="btn btn-sm btn-outline-danger" type="submit">Clear</button>
+        </form>
+      </div>
+      {% endif %}
       <form method="post" enctype="multipart/form-data" class="mb-4" id="util-form">
         <input type="hidden" name="mode" value="util">
         <input type="hidden" name="util_name" id="util-name-input" value="{{ default_util }}">
@@ -38,11 +47,11 @@
         <div class="mb-3" id="input-mode-group">
           <label class="form-label">Input Mode</label><br>
           <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="input_mode" id="mode-single" value="single" checked>
+            <input class="form-check-input" type="radio" name="input_mode" id="mode-single" value="single" {% if default_mode != 'file' %}checked{% endif %}>
             <label class="form-check-label" for="mode-single">Single Input</label>
           </div>
           <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="input_mode" id="mode-upload" value="file">
+            <input class="form-check-input" type="radio" name="input_mode" id="mode-upload" value="file" {% if default_mode == 'file' %}checked{% endif %}>
             <label class="form-check-label" for="mode-upload">Upload input list</label>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- chain CSV output from one utility to the next
- allow clearing saved CSV file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f6c110e8832d9da560d0016b23e7