### PR TITLE
Update UI text for Apollo tool

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,6 +60,7 @@ UTILITY_TITLES = {
     "find_a_user_by_name_and_keywords": "Find LinkedIn Profile by Name",
     "find_user_by_job_title": "Find LinkedIn Profile by Job Title",
     "find_users_by_name_and_keywords": "Bulk Find LinkedIn Profiles",
+    "apollo_info": "Enrich Lead With Apollo.io",
     "fetch_html_playwright": "Scrape Website HTML (Playwright)",
     "extract_companies_from_image": "Extract Companies from Image",
     "generate_image": "Generate Image",

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -30,7 +30,7 @@
     <div class="col-md-8">
       {% if prev_csv %}
       <div class="alert alert-secondary d-flex align-items-center mb-3">
-        <div class="flex-grow-1">Using previous CSV: {{ prev_csv }}</div>
+        <div class="flex-grow-1">Using previous output CSV as input: {{ prev_csv }}</div>
         <form method="post" class="ms-2">
           <input type="hidden" name="action" value="clear_csv">
           <button class="btn btn-sm btn-outline-danger" type="submit">Clear</button>
@@ -77,14 +77,14 @@
             {% if download_name %}
               {% set is_image = download_name.endswith('.png') %}
               <a class="btn btn-secondary" href="{{ url_for('download_file', filename=download_name) }}">
-                {{ 'Download Image' if is_image else 'Download CSV' }}
+                {{ 'Download Image' if is_image else 'Download Output CSV' }}
               </a>
             {% endif %}
           </div>
         {% elif download_name %}
           {% set is_image = download_name.endswith('.png') %}
           <a class="btn btn-secondary mt-2" href="{{ url_for('download_file', filename=download_name) }}">
-            {{ 'Download Image' if is_image else 'Download CSV' }}
+            {{ 'Download Image' if is_image else 'Download Output CSV' }}
           </a>
         {% endif %}
         {% if image_src %}


### PR DESCRIPTION
## Summary
- rename Apollo Info to **Enrich Lead With Apollo.io** in the UI
- show clearer message when a previous output CSV is reused
- rename download button text to **Download Output CSV**

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490214e0d4832dbdeae7fc105ea00d