### PR TITLE
Add email generation utility

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -265,6 +265,15 @@ task run:command -- send_email_smtp recipient@example.com --subject "Hi" --body 
 task run:command -- send_slack_message "Deployment finished"
 ```
 
+### Generate Email Copy
+
+`generate_email.py` produces a subject and body for a lead using OpenAI. Pass the lead data as JSON with `--lead` or provide a CSV via `--csv` and `--output_csv`. The `OPENAI_API_KEY` environment variable must be set.
+
+```bash
+task run:command -- generate_email --lead '{"full_name": "John Doe"}' \
+    --instructions "Write a short intro email"
+```
+
 ## Generate Image with OpenAI
 
 `generate_image.py` creates an image from a text prompt. If you supply an `--image-url` the script sends the image along with the prompt to the OpenAI responses API for editing instead of calling the legacy `images.edit` endpoint. It requires the `OPENAI_API_KEY` environment variable.

--- a/tests/test_generate_email.py
+++ b/tests/test_generate_email.py
@@ -1,0 +1,29 @@
+import csv
+import json
+from utils import generate_email as mod
+
+
+class DummyEmail(mod.EmailCopy):
+    pass
+
+
+async def fake_structured(prompt: str, model):
+    return DummyEmail(subject="Hi", body="Body"), "SUCCESS"
+
+
+def test_generate_email(monkeypatch):
+    monkeypatch.setattr(mod, "_get_structured_data_internal", fake_structured)
+    result = mod.generate_email({"name": "John"}, "Say hi")
+    assert result["subject"] == "Hi"
+    assert result["body"] == "Body"
+
+
+def test_generate_emails_from_csv(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "generate_email", lambda row, ins: {"subject": "S", "body": "B"})
+    in_file = tmp_path / "in.csv"
+    in_file.write_text("name\nJohn\n")
+    out_file = tmp_path / "out.csv"
+    mod.generate_emails_from_csv(in_file, out_file, "Ins")
+    rows = list(csv.DictReader(out_file.open()))
+    assert rows[0]["email_subject"] == "S"
+    assert rows[0]["email_body"] == "B"

--- a/utils/generate_email.py
+++ b/utils/generate_email.py
@@ -1,0 +1,111 @@
+"""Generate an email subject and body using OpenAI."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    from pydantic import BaseModel
+except ImportError:  # pragma: no cover - tests use stub
+    from pydantic_stub import BaseModel
+
+from utils.extract_from_webpage import _get_structured_data_internal
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class EmailCopy(BaseModel):
+    subject: str
+    body: str
+
+
+async def _generate_email_async(lead: Dict[str, Any], instructions: str) -> EmailCopy:
+    """Return ``EmailCopy`` generated for ``lead`` following ``instructions``."""
+
+    prompt = (
+        "Compose a short sales email as JSON.\n"
+        f"Instructions:\n{instructions}\n\n"
+        f"Lead information:\n{json.dumps(lead)}\n\n"
+        "Return valid JSON with keys 'subject' and 'body'."
+    )
+    result, status = await _get_structured_data_internal(prompt, EmailCopy)
+    if status != "SUCCESS" or result is None:
+        logger.error("Failed to generate email from LLM")
+        raise RuntimeError("LLM email generation failed")
+    return result
+
+
+def generate_email(lead: Dict[str, Any], instructions: str) -> Dict[str, str]:
+    """Generate an email synchronously for ``lead``."""
+    result = asyncio.run(_generate_email_async(lead, instructions))
+    return json.loads(result.model_dump_json())
+
+
+def generate_emails_from_csv(
+    input_file: str | Path, output_file: str | Path, instructions: str
+) -> None:
+    """Generate emails for each row of ``input_file`` and write results."""
+
+    in_path = Path(input_file)
+    out_path = Path(output_file)
+
+    with in_path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+
+    out_fields = list(fieldnames)
+    if "email_subject" not in out_fields:
+        out_fields.append("email_subject")
+    if "email_body" not in out_fields:
+        out_fields.append("email_body")
+
+    processed: list[dict[str, str]] = []
+    for row in rows:
+        result = generate_email(row, instructions)
+        row["email_subject"] = result.get("subject", "")
+        row["email_body"] = result.get("body", "")
+        processed.append(row)
+
+    with out_path.open("w", newline="", encoding="utf-8") as out_fh:
+        writer = csv.DictWriter(out_fh, fieldnames=out_fields)
+        writer.writeheader()
+        for row in processed:
+            writer.writerow(row)
+
+    logger.info("Wrote generated emails to %s", out_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate an email using OpenAI")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--lead", help="JSON string with lead info")
+    group.add_argument("--csv", help="Input CSV file with leads")
+    parser.add_argument(
+        "--instructions", required=True, help="Instructions for generating the email"
+    )
+    parser.add_argument("--output_csv", help="Output CSV path when using --csv")
+    args = parser.parse_args()
+
+    if args.lead:
+        try:
+            data = json.loads(args.lead)
+        except json.JSONDecodeError as exc:
+            raise ValueError("lead must be valid JSON") from exc
+        result = generate_email(data, args.instructions)
+        print(json.dumps(result, indent=2))
+    else:
+        if not args.output_csv:
+            raise ValueError("--output_csv is required when using --csv")
+        generate_emails_from_csv(args.csv, args.output_csv, args.instructions)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `generate_email.py` utility for generating email subject and body using OpenAI
- document new utility in the usage guide
- add tests covering JSON generation and CSV mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684910eb7910832d87b39af458bbdae2