### PR TITLE
Allow instructions for scoring leads in CSV mode

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -223,7 +223,7 @@
         }
         const mode = isUploadOnly ? 'file' : document.querySelector('input[name="input_mode"]:checked').value;
         document.getElementById('file-container').style.display = mode === 'file' ? '' : 'none';
-        const paramsVisible = !(mode === 'file' && util !== 'call_openai_llm');
+        const paramsVisible = !(mode === 'file' && !['call_openai_llm', 'score_lead'].includes(util));
         document.getElementById('params-container').style.display = paramsVisible ? '' : 'none';
       }
     document.querySelectorAll('.util-card').forEach(card => {


### PR DESCRIPTION
## Summary
- ensure the "Score Leads" utility shows parameter inputs even when uploading a CSV

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849161c46f4832da33efd99f137d115