### PR TITLE
Update email generation instructions parameter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -200,7 +200,7 @@ UTILITY_PARAMETERS = {
         {"name": "--companies", "label": "Fetch companies", "type": "boolean"},
     ],
     "generate_email": [
-        {"name": "--instructions", "label": "Instructions"},
+        {"name": "--email_generation_instructions", "label": "Email generation instructions"},
     ],
     "score_lead": [
         {"name": "--instructions", "label": "Instructions"},
@@ -427,9 +427,11 @@ def run_utility():
                     output_csv_path = None
             elif util_name == 'generate_email':
                 out_path = common.make_temp_csv_filename(util_name)
-                instructions = request.form.get('--instructions', '')
+                email_instructions = request.form.get('--email_generation_instructions', '')
                 try:
-                    generate_email.generate_emails_from_csv(uploaded, out_path, instructions)
+                    generate_email.generate_emails_from_csv(
+                        uploaded, out_path, email_instructions
+                    )
                     download_name = out_path
                     output_csv_path = out_path
                     util_output = None

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -271,7 +271,7 @@ task run:command -- send_slack_message "Deployment finished"
 
 ```bash
 task run:command -- generate_email --lead '{"full_name": "John Doe"}' \
-    --instructions "Write a short intro email"
+    --email_generation_instructions "Write a short intro email"
 ```
 
 ## Generate Image with OpenAI


### PR DESCRIPTION
## Summary
- rename instructions parameter to `--email_generation_instructions`
- update web app to pass new parameter when generating emails
- document new argument in usage docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491c131788832d9e5eb23ff81819ee