### PR TITLE
Add Previous Output input option

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -308,6 +308,7 @@ def run_utility():
     if request.method == 'POST':
         file = request.files.get('csv_file')
         uploaded = None
+        input_mode = request.form.get('input_mode', 'single')
         selected_json = request.form.get('selected_rows', '')
         if selected_json:
             try:
@@ -329,10 +330,14 @@ def run_utility():
             uploaded = filename
         if (
             not uploaded
-            and (
-                request.form.get('input_mode') == 'file'
-                or util_name in UPLOAD_ONLY_UTILS
-            )
+            and input_mode == 'previous'
+            and prev_csv
+            and os.path.exists(prev_csv)
+        ):
+            uploaded = prev_csv
+        if (
+            not uploaded
+            and util_name in UPLOAD_ONLY_UTILS
             and prev_csv
             and os.path.exists(prev_csv)
         ):
@@ -526,7 +531,7 @@ def run_utility():
         upload_only=UPLOAD_ONLY_UTILS,
         image_src=image_src,
         prev_csv=prev_csv,
-        default_mode='file' if prev_csv else 'single',
+        default_mode='previous' if prev_csv else 'single',
     )
 
 

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -47,13 +47,19 @@
         <div class="mb-3" id="input-mode-group">
           <label class="form-label">Input Mode</label><br>
           <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="input_mode" id="mode-single" value="single" {% if default_mode != 'file' %}checked{% endif %}>
+            <input class="form-check-input" type="radio" name="input_mode" id="mode-single" value="single" {% if default_mode == 'single' %}checked{% endif %}>
             <label class="form-check-label" for="mode-single">Single Input</label>
           </div>
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="input_mode" id="mode-upload" value="file" {% if default_mode == 'file' %}checked{% endif %}>
             <label class="form-check-label" for="mode-upload">Upload input list</label>
           </div>
+          {% if prev_csv %}
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="input_mode" id="mode-prev" value="previous" {% if default_mode == 'previous' %}checked{% endif %}>
+            <label class="form-check-label" for="mode-prev">Use Previous Output</label>
+          </div>
+          {% endif %}
         </div>
         <div id="params-container"></div>
         <div class="mb-3" id="file-container" style="display:none;">
@@ -223,7 +229,7 @@
         }
         const mode = isUploadOnly ? 'file' : document.querySelector('input[name="input_mode"]:checked').value;
         document.getElementById('file-container').style.display = mode === 'file' ? '' : 'none';
-        const paramsVisible = !(mode === 'file' && !['call_openai_llm', 'score_lead'].includes(util));
+        const paramsVisible = !(['file', 'previous'].includes(mode) && !['call_openai_llm', 'score_lead'].includes(util));
         document.getElementById('params-container').style.display = paramsVisible ? '' : 'none';
       }
     document.querySelectorAll('.util-card').forEach(card => {


### PR DESCRIPTION
## Summary
- support `previous` input mode in Flask app
- show 3 input mode radios including *Use Previous Output*
- hide utility parameters when using previous output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491da6818c832d831a8f8480d6fe3e