### PR TITLE
Fix previous output mode update

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -519,6 +519,7 @@ def run_utility():
         input_rows = _load_csv_preview(input_csv_path)
     if output_csv_path and os.path.exists(output_csv_path):
         session['prev_csv_path'] = output_csv_path
+        prev_csv = output_csv_path
     return render_template(
         'run_utility.html',
         utils=utils_list,


### PR DESCRIPTION
## Summary
- automatically enable "Use Previous Output" after running a utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849201aa554832da9638e2b331f0c9a