### PR TITLE
Ensure webhook modes and API key errors

### DIFF
--- a/docs/push_leads_to_dhisana.md
+++ b/docs/push_leads_to_dhisana.md
@@ -8,3 +8,11 @@ After running any tool you can send the results directly to Dhisana for enrichme
 4. Run any utility. When results contain LinkedIn profile URLs a **Push to Dhisana AI Contacts** button will appear. Click it to push the leads to Dhisana.
 
 The platform will qualify and research each lead, score them and automatically add them to the correct outreach campaign.
+
+## Input Modes
+
+You can push leads to Dhisana regardless of how you supplied data to a utility:
+
+1. **Single Input** – When running a tool with a single input value the output panel includes the button if any LinkedIn URLs are detected.
+2. **CSV Input** – Upload a CSV file and run a utility. After it finishes you can push all LinkedIn URLs from the resulting CSV.
+3. **Use Previous Output** – Switch the input mode to *Use Previous Output* to feed an earlier CSV back into another tool. The push button is still available so you can send those results to Dhisana as well.

--- a/tests/test_openai_missing_key.py
+++ b/tests/test_openai_missing_key.py
@@ -1,0 +1,8 @@
+import asyncio
+import pytest
+from utils import extract_from_webpage as mod
+
+def test_missing_openai_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        asyncio.run(mod._get_structured_data_internal("prompt", mod.Lead))

--- a/tests/test_send_slack_message.py
+++ b/tests/test_send_slack_message.py
@@ -1,4 +1,5 @@
 import types
+import pytest
 from utils import send_slack_message as mod
 
 class DummyReq:
@@ -18,9 +19,10 @@ def test_send_with_env(monkeypatch):
     assert dummy.calls[0][1] == {"text": "hello"}
 
 
-def test_skip_without_webhook(monkeypatch):
+def test_error_without_webhook(monkeypatch):
     dummy = DummyReq()
     monkeypatch.setattr(mod, "requests", types.SimpleNamespace(post=dummy.post))
     monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
-    mod.send_slack_message("hi")
+    with pytest.raises(RuntimeError):
+        mod.send_slack_message("hi")
     assert dummy.calls == []

--- a/utils/extract_from_webpage.py
+++ b/utils/extract_from_webpage.py
@@ -58,8 +58,7 @@ async def _get_structured_data_internal(prompt: str, model: Type[BaseModel]) -> 
     """Send ``prompt`` to OpenAI and parse the response as ``model``."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        logger.error("OPENAI_API_KEY environment variable is not set")
-        return None, "ERROR"
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
 
     client = AsyncOpenAI(api_key=api_key)
     try:

--- a/utils/send_slack_message.py
+++ b/utils/send_slack_message.py
@@ -18,8 +18,7 @@ def send_slack_message(message: str, webhook: Optional[str] = None) -> None:
 
     webhook = webhook or os.getenv("SLACK_WEBHOOK_URL")
     if not webhook:
-        logger.info("SLACK_WEBHOOK_URL not configured; skipping Slack message")
-        return
+        raise RuntimeError("SLACK_WEBHOOK_URL environment variable is not set")
 
     try:
         requests.post(webhook, json={"text": message}, timeout=5)


### PR DESCRIPTION
## Summary
- clarify Dhisana webhook docs with input modes
- raise RuntimeError when Slack webhook missing
- raise RuntimeError when OPENAI_API_KEY missing
- update Slack test for new error behaviour
- add test for missing OPENAI key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684929aa44ac832d864faa82a112bbda