### PR TITLE
Add simple login with username/password

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,6 +37,15 @@
           <li class="nav-item">
             <a class="nav-link" href="https://join.slack.com/t/dhisanaaicommunity/shared_invite/zt-37bzb09dc-VFgu_1PwM2CXORH1e6s8Xg" target="_blank">Join our Slack community</a>
           </li>
+          {% if session.get('logged_in') %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          </li>
+          {% else %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+          </li>
+          {% endif %}
         </ul>
       </div>
     </nav>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-info" role="alert">
+        {% for m in messages %}
+          <div>{{ m }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+  <div class="row justify-content-center">
+    <div class="col-md-4">
+      <h2 class="mb-3">Login</h2>
+      <form method="post">
+        <div class="mb-3">
+          <label class="form-label" for="username">Username</label>
+          <input class="form-control" type="text" id="username" name="username">
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="password">Password</label>
+          <input class="form-control" type="password" id="password" name="password">
+        </div>
+        <button class="btn btn-primary" type="submit">Login</button>
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add credential loader that defaults to user_XXXX password if unset
- enforce login via before_request
- add login and logout routes with templates
- show login/logout links in base navbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493e6a0500832dac27991923e60418