### PR TITLE
Prefill login username

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -232,10 +232,26 @@ def load_env():
     return dotenv_values(ENV_FILE)
 
 
+def get_default_username() -> str:
+    """Return the default username for the login form."""
+    env = load_env()
+    return (
+        env.get("APP_USER")
+        or os.environ.get("APP_USER")
+        or "user"
+    )
+
+
 def get_credentials() -> tuple[str, str]:
     """Return (username, password) for the login page."""
     env = load_env()
-    username = env.get("APP_USERNAME") or os.environ.get("APP_USERNAME") or "user"
+    username = (
+        env.get("APP_USERNAME")
+        or os.environ.get("APP_USERNAME")
+        or env.get("APP_USER")
+        or os.environ.get("APP_USER")
+        or "user"
+    )
     password = env.get("APP_PASSWORD") or os.environ.get("APP_PASSWORD")
     if not password:
         password = f"user_{random.randint(1000, 9999)}"
@@ -321,7 +337,7 @@ def login():
             session['logged_in'] = True
             return redirect(url_for('run_utility'))
         flash('Invalid credentials.')
-    return render_template('login.html')
+    return render_template('login.html', default_username=get_default_username())
 
 
 @app.route('/logout')

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -16,7 +16,7 @@
       <form method="post">
         <div class="mb-3">
           <label class="form-label" for="username">Username</label>
-          <input class="form-control" type="text" id="username" name="username">
+          <input class="form-control" type="text" id="username" name="username" value="{{ default_username }}">
         </div>
         <div class="mb-3">
           <label class="form-label" for="password">Password</label>


### PR DESCRIPTION
## Summary
- support APP_USER env var
- prefill login form with env-provided default username

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684942d2f3d4832db954d098278292fd