### PR TITLE
Add history tab listing CSVs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import base64
 import random
+import datetime
 from utils import (
     push_lead_to_dhisana_webhook,
     linkedin_search_to_csv,
@@ -660,6 +661,26 @@ def help_page():
     """Display simple help information about the app and utilities."""
     utils_list = _list_utils()
     return render_template("help.html", utils=utils_list)
+
+
+@app.route("/history")
+def history():
+    """Display recent CSV files from the data directory."""
+    out_dir = common.get_output_dir()
+    files: list[dict[str, str]] = []
+    if out_dir.is_dir():
+        csv_paths = [p for p in out_dir.iterdir() if p.suffix.lower() == ".csv"]
+        csv_paths.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for p in csv_paths[:50]:
+            files.append(
+                {
+                    "name": p.name,
+                    "mtime": datetime.datetime.fromtimestamp(p.stat().st_mtime).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    ),
+                }
+            )
+    return render_template("history.html", csv_files=files)
 
 
 @app.route("/download/<path:filename>")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -22,12 +22,15 @@
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('run_utility') }}">Run a Utility</a>
           </li>
-          <li class="nav-item">
+        <li class="nav-item">
             <a class="nav-link" href="{{ url_for('settings') }}">Settings</a>
-          </li>
-          <li class="nav-item">
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('history') }}">History</a>
+        </li>
+        <li class="nav-item">
             <a class="nav-link" href="{{ url_for('help_page') }}">Help</a>
-          </li>
+        </li>
           <li class="nav-item">
             <a class="nav-link" href="https://github.com/dhisana-ai/gtm-ai-tools" target="_blank">GitHub</a>
           </li>

--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>History</h2>
+  {% if csv_files %}
+  <table class="table">
+    <thead>
+      <tr><th>Filename</th><th>Modified</th></tr>
+    </thead>
+    <tbody>
+      {% for f in csv_files %}
+      <tr>
+        <td><a href="{{ url_for('download_file', filename=f.name) }}">{{ f.name }}</a></td>
+        <td>{{ f.mtime }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>No CSV files found.</p>
+  {% endif %}
+{% endblock %}

--- a/tests/test_app_history.py
+++ b/tests/test_app_history.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+import datetime
+
+# Provide minimal python-dotenv stub if missing
+if 'dotenv' not in sys.modules:
+    dotenv = types.ModuleType('dotenv')
+    dotenv.dotenv_values = lambda *a, **kw: {}
+    dotenv.set_key = lambda *a, **kw: None
+    sys.modules['dotenv'] = dotenv
+
+# Provide minimal flask stub if not installed
+if 'flask' not in sys.modules:
+    flask = types.ModuleType('flask')
+
+    class DummyRequest:
+        def __init__(self):
+            self.form = {}
+            self.files = {}
+            self.method = 'GET'
+
+    request = DummyRequest()
+
+    def render_template(name, **ctx):
+        render_template.context = ctx
+        return ctx
+
+    def redirect(url):
+        return url
+
+    def url_for(name, **kw):
+        return f'/{name}'
+
+    def flash(msg):
+        pass
+
+    def send_from_directory(directory, filename, as_attachment=False):
+        return os.path.join(directory, filename)
+
+    class DummyFlask:
+        def __init__(self, *a, **kw):
+            pass
+        def route(self, *a, **kw):
+            def decorator(f):
+                return f
+            return decorator
+
+    flask.Flask = DummyFlask
+    flask.render_template = render_template
+    flask.request = request
+    flask.redirect = redirect
+    flask.url_for = url_for
+    flask.flash = flash
+    flask.send_from_directory = send_from_directory
+    sys.modules['flask'] = flask
+
+from app import history
+from utils import common
+
+
+def test_history(monkeypatch, tmp_path):
+    d = tmp_path
+    f1 = d / 'a.csv'
+    f2 = d / 'b.csv'
+    f1.write_text('a')
+    f2.write_text('b')
+    old = (datetime.datetime.now() - datetime.timedelta(seconds=10)).timestamp()
+    os.utime(f1, (old, old))
+    monkeypatch.setattr(common, 'get_output_dir', lambda: d)
+    ctx = history()
+    files = [item['name'] for item in ctx['csv_files']]
+    assert files == ['b.csv', 'a.csv']


### PR DESCRIPTION
## Summary
- add new History navigation link
- list recent CSV files under `/data` via `/history`
- create `history.html` template to show the file table
- test the new history endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849993c4284832d93bca5353831e383