### PR TITLE
Rename Extract from Webpage to Extract Leads From Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ download link will be displayed. Plain text output is shown in the page.
 - [Update Salesforce Contact](docs/utils_usage.md#update-salesforce-contact) – modify contact fields.
 - [Add Salesforce Note](docs/utils_usage.md#add-salesforce-note) – attach a note to a contact.
 - [Scrape Website HTML (Playwright)](utils/fetch_html_playwright.py) – scrape page HTML for lead extraction.
- - [Extract from Webpage](utils/extract_from_webpage.py) – pull leads and companies from any website. Supports pagination with `--next_page_selector` and `--max_next_pages`.
+- [Extract Leads From Website](utils/extract_from_webpage.py) – pull leads and companies from any website. Supports pagination with `--next_page_selector` and `--max_next_pages`.
 - [Push Leads to Dhisana](docs/push_leads_to_dhisana.md) – send scraped LinkedIn URLs to Dhisana for enrichment and outreach.
 - [Create Dhisana Webhook](docs/create_dhisana_webhook.md) – configure your webhook and API key.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -79,6 +79,7 @@ UTILITY_TITLES = {
     "apollo_info": "Enrich Lead With Apollo.io",
     "fetch_html_playwright": "Scrape Website HTML (Playwright)",
     "extract_companies_from_image": "Extract Companies from Image",
+    "extract_from_webpage": "Extract Leads From Website",
     "generate_image": "Generate Image",
     "score_lead": "Score Leads",
     "check_email_zero_bounce": "Validate Email",

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -375,6 +375,24 @@ the `OPENAI_API_KEY` and `SERPER_API_KEY` environment variables.
 task run:command -- extract_companies_from_image http://example.com/logo.png
 ```
 
+## Extract Leads From Website
+
+`extract_from_webpage.py` scrapes a page with Playwright and uses an LLM to
+parse leads or organizations from the text. Provide the starting URL and use
+`--lead` or `--leads` to control how many leads are returned. Pagination can be
+handled with `--next_page_selector` and `--max_next_pages`.
+
+```bash
+task run:command -- extract_from_webpage --leads https://example.com/team \
+    --output_csv /workspace/output.csv
+```
+
+The path supplied with `--output_csv` is created inside the container. Since the
+local `output/` directory maps to `/workspace`, the file will be available at
+`output/output.csv` on your host system. In the web interface you can switch to
+**Use Previous Output** and feed this CSV into another tool such as **Enrich
+Lead With Apollo.io**.
+
 
 ## OpenAI Codex CLI
 


### PR DESCRIPTION
## Summary
- rename Extract from Webpage tool in the UI
- document how to run it and use previous output
- update README bullet for the renamed tool

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684d733bcb98832da8a7a1994f092d95