### PR TITLE
Add JS automation and parse instructions to web extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ download link will be displayed. Plain text output is shown in the page.
 - [Update Salesforce Contact](docs/utils_usage.md#update-salesforce-contact) – modify contact fields.
 - [Add Salesforce Note](docs/utils_usage.md#add-salesforce-note) – attach a note to a contact.
 - [Scrape Website HTML (Playwright)](utils/fetch_html_playwright.py) – scrape page HTML for lead extraction.
-- [Extract Leads From Website](utils/extract_from_webpage.py) – pull leads and companies from any website. Supports pagination with `--next_page_selector` and `--max_next_pages`.
+- [Extract Leads From Website](utils/extract_from_webpage.py) – pull leads and companies from any website. You can provide natural language actions for page navigation and parsing with options like `--initial_actions` and `--pagination_actions`.
 - [Push Leads to Dhisana](docs/push_leads_to_dhisana.md) – send scraped LinkedIn URLs to Dhisana for enrichment and outreach.
 - [Create Dhisana Webhook](docs/create_dhisana_webhook.md) – configure your webhook and API key.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,7 +50,10 @@ except Exception:  # pragma: no cover - fallback for test stubs
     session = {}
 from dotenv import dotenv_values, set_key
 import openai
-import numpy as np
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional
+    np = None
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -217,6 +220,11 @@ UTILITY_PARAMETERS = {
         {"name": "--companies", "label": "Fetch companies", "type": "boolean"},
         {"name": "--next_page_selector", "label": "Next page selector"},
         {"name": "--max_next_pages", "label": "Max next pages"},
+        {"name": "--initial_actions", "label": "Initial actions"},
+        {"name": "--page_actions", "label": "Page actions"},
+        {"name": "--parse_instructions", "label": "Parse instructions"},
+        {"name": "--pagination_actions", "label": "Pagination actions"},
+        {"name": "--max_pages", "label": "Max pages"},
         {"name": "--output_csv", "label": "Output CSV"},
     ],
     "generate_email": [

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -379,8 +379,13 @@ task run:command -- extract_companies_from_image http://example.com/logo.png
 
 `extract_from_webpage.py` scrapes a page with Playwright and uses an LLM to
 parse leads or organizations from the text. Provide the starting URL and use
-`--lead` or `--leads` to control how many leads are returned. Pagination can be
-handled with `--next_page_selector` and `--max_next_pages`.
+`--lead` or `--leads` to control how many leads are returned. You can run custom
+JavaScript on the initial page load, on each page load and for pagination by
+supplying natural language instructions with `--initial_actions`,
+`--page_actions` and `--pagination_actions`. Parsing behaviour can be tweaked
+with `--parse_instructions`. Use `--max_pages` to limit how many pages are
+navigated. The previous `--next_page_selector` and `--max_next_pages` options
+still work as a fallback.
 
 ```bash
 task run:command -- extract_from_webpage --leads https://example.com/team \

--- a/tests/test_extract_from_webpage.py
+++ b/tests/test_extract_from_webpage.py
@@ -56,3 +56,22 @@ def test_extract_companies_with_pagination(monkeypatch):
     )
     names = [c.organization_name for c in companies]
     assert names == ["Acme", "Beta"]
+
+
+def test_parse_instructions_in_prompt(monkeypatch):
+    monkeypatch.setattr(mod, "_fetch_and_clean", fake_fetch_lead)
+
+    captured = {}
+
+    async def fake_get(prompt: str, model):
+        captured["prompt"] = prompt
+        return mod.LeadList(leads=[mod.Lead(first_name="Jane")]), "SUCCESS"
+
+    monkeypatch.setattr(mod, "_get_structured_data_internal", fake_get)
+    asyncio.run(
+        mod.extract_lead_from_webpage(
+            "http://x.com",
+            parse_instructions="Look carefully",
+        )
+    )
+    assert "Look carefully" in captured["prompt"]


### PR DESCRIPTION
## Summary
- enhance `extract_from_webpage.py` with optional JS-based actions
- allow passing parsing instructions
- expose new CLI flags and update UI parameters
- document new usage
- extend tests and provide missing stubs for Flask/numpy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfc4f4d1c832da73fa07e8f2f1eeb