### PR TITLE
Update extract_from_webpage defaults

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -214,10 +214,10 @@ UTILITY_PARAMETERS = {
     ],
     "extract_from_webpage": [
         {"name": "url", "label": "Website URL"},
-        {"name": "--lead", "label": "Fetch lead", "type": "boolean"},
-        {"name": "--leads", "label": "Fetch leads", "type": "boolean"},
-        {"name": "--company", "label": "Fetch company", "type": "boolean"},
-        {"name": "--companies", "label": "Fetch companies", "type": "boolean"},
+        {"name": "--lead", "label": "Extract One Lead", "type": "boolean"},
+        {"name": "--leads", "label": "Extract Multiple Leads", "type": "boolean"},
+        {"name": "--company", "label": "Extract One Company", "type": "boolean"},
+        {"name": "--companies", "label": "Extract Multiple Companies", "type": "boolean"},
         {"name": "--next_page_selector", "label": "Next page selector"},
         {"name": "--max_next_pages", "label": "Max next pages"},
         {"name": "--initial_actions", "label": "Initial actions"},
@@ -225,7 +225,6 @@ UTILITY_PARAMETERS = {
         {"name": "--parse_instructions", "label": "Parse instructions"},
         {"name": "--pagination_actions", "label": "Pagination actions"},
         {"name": "--max_pages", "label": "Max pages"},
-        {"name": "--output_csv", "label": "Output CSV"},
     ],
     "generate_email": [
         {
@@ -468,6 +467,9 @@ def run_utility():
                         insert_at = i
                         break
                 cmd.insert(insert_at, out_path)
+            elif util_name == "extract_from_webpage":
+                out_path = common.make_temp_csv_filename(util_name)
+                cmd.extend(["--output_csv", out_path])
             return cmd
 
         def run_cmd(cmd: list[str]) -> tuple[str, str, str]:

--- a/utils/extract_from_webpage.py
+++ b/utils/extract_from_webpage.py
@@ -459,10 +459,10 @@ def main() -> None:
         description="Extract leads or companies from a web page"
     )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--lead", action="store_true", help="Fetch first lead")
-    group.add_argument("--leads", action="store_true", help="Fetch all leads")
-    group.add_argument("--company", action="store_true", help="Fetch first company")
-    group.add_argument("--companies", action="store_true", help="Fetch all companies")
+    group.add_argument("--lead", action="store_true", help="Extract one lead")
+    group.add_argument("--leads", action="store_true", help="Extract multiple leads")
+    group.add_argument("--company", action="store_true", help="Extract one company")
+    group.add_argument("--companies", action="store_true", help="Extract multiple companies")
     parser.add_argument("url", help="Website URL")
     parser.add_argument("--next_page_selector", help="CSS selector for next page link")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- rename extract_from_webpage boolean labels to use "Extract" wording
- auto generate CSV path for extract_from_webpage in UI
- update CLI help for new wording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e01833364832daf81ba6252dd4976