### PR TITLE
Add CSV output for single extract_from_webpage runs

### DIFF
--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -387,6 +387,9 @@ with `--parse_instructions`. Use `--max_pages` to limit how many pages are
 navigated. The previous `--next_page_selector` and `--max_next_pages` options
 still work as a fallback.
 
+If `--output_csv` is not supplied, the utility now prints the CSV data to
+standard output instead of JSON.
+
 ```bash
 task run:command -- extract_from_webpage --leads https://example.com/team \
     --output_csv /workspace/output.csv


### PR DESCRIPTION
## Summary
- support writing CSV output directly to stdout when running `extract_from_webpage` without `--output_csv`
- allow internal CSV helpers to accept a file path or file object
- document the new behaviour in `utils_usage.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0313ac04832d9bef3dfaa4b9ec53