### PR TITLE
Fix default flag for webpage extraction

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -469,6 +469,11 @@ def run_utility():
                 cmd.insert(insert_at, out_path)
             elif util_name == "extract_from_webpage":
                 out_path = common.make_temp_csv_filename(util_name)
+                if not any(
+                    f in cmd
+                    for f in ("--lead", "--leads", "--company", "--companies")
+                ):
+                    cmd.append("--leads")
                 cmd.extend(["--output_csv", out_path])
             return cmd
 


### PR DESCRIPTION
## Summary
- ensure the app provides a default `--leads` flag when calling `extract_from_webpage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e05a2f034832d887df4a204500463