### PR TITLE
Fix category dropdown order

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -435,7 +435,10 @@ def run_utility():
     input_csv_path: str | None = None
     output_csv_path: str | None = None
     utils_list = _list_utils()
-    tags_list = sorted({t for tags in UTILITY_TAGS.values() for t in tags})
+    tags_set = {t for tags in UTILITY_TAGS.values() for t in tags}
+    tag_order = ["find", "enrich", "score", "route"]
+    tags_list = [t for t in tag_order if t in tags_set]
+    tags_list.extend(sorted(tags_set - set(tag_order)))
     util_name = request.form.get("util_name", "linkedin_search_to_csv")
     prev_csv = session.get("prev_csv_path")
     if prev_csv and os.path.exists(prev_csv):


### PR DESCRIPTION
## Summary
- ensure `Filter by Category` dropdown orders known categories as
  Find/Search leads, Enrich Leads, Score leads, Route leads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e1099e104832da9765c3da14b7507