### PR TITLE
Fix openai calls for new responses API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,12 @@ if 'openai' not in sys.modules:
     openai.OpenAI = DummyClient
     class DummyAsyncOpenAI:
         def __init__(self, api_key=None):
+            self.responses = types.SimpleNamespace(create=self._create)
+        async def _create(self, **kwargs):
+            return types.SimpleNamespace(output_text="{}")
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
             pass
         class chat:
             class completions:

--- a/utils/extract_from_webpage.py
+++ b/utils/extract_from_webpage.py
@@ -68,14 +68,13 @@ async def _get_structured_data_internal(
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY environment variable is not set")
 
-    client = AsyncOpenAI(api_key=api_key)
     try:
-        response = await client.chat.completions.create(
-            model=common.get_openai_model(),
-            messages=[{"role": "user", "content": prompt}],
-            response_format={"type": "json_object"},
-        )
-        text = response.choices[0].message.content or ""
+        async with AsyncOpenAI(api_key=api_key) as client:
+            response = await client.responses.create(
+                model=common.get_openai_model(),
+                input=prompt,
+            )
+        text = getattr(response, "output_text", "") or ""
         if not text:
             return None, "ERROR"
         return model.model_validate_json(text), "SUCCESS"


### PR DESCRIPTION
## Summary
- use async context for AsyncOpenAI and call the `responses` API
- update AsyncOpenAI test stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e61b8caec832daa77fd5ce3cd15bc