### PR TITLE
Enhance find_company_info tool

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -171,8 +171,10 @@ UTILITY_PARAMETERS = {
         {"name": "search_keywords", "label": "Search keywords"},
     ],
     "find_company_info": [
-        {"name": "company_name", "label": "Company name"},
-        {"name": "--location", "label": "Company location"},
+        {"name": "--organization_name", "label": "Organization name"},
+        {"name": "--organization_linkedin_url", "label": "Organization LinkedIn URL"},
+        {"name": "--organization_website", "label": "Organization website"},
+        {"name": "--location", "label": "Organization location"},
     ],
     "find_contact_with_findymail": [
         {"name": "full_name", "label": "Full name"},

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -49,16 +49,15 @@ After the command finishes, everything in `output/` is also copied to
 
 ## Find Company Info
 
-`find_company_info.py` looks up a company's website, primary domain and LinkedIn page using Google search. It uses the `SERPER_API_KEY` environment variable for Google queries.
-The LinkedIn URL returned is normalized to the `https://www.linkedin.com/company/<id>` form.
+`find_company_info.py` looks up a company's website, primary domain and LinkedIn page using Google search. It uses the `SERPER_API_KEY` environment variable for Google queries. The LinkedIn URL returned is normalized to the `https://www.linkedin.com/company/<id>` form.
 
-Run it with the company name and optional location:
+Provide an organization name, LinkedIn URL or website:
 
 ```bash
-task run:command -- find_company_info "Dhisana" -l "San Francisco"
+task run:command -- find_company_info --organization_name "Dhisana" --location "San Francisco"
 ```
 
-The script prints a JSON object containing `company_website`, `company_domain` and `linkedin_url`.
+The script prints JSON with `organization_name`, `organization_website`, `primary_domain_of_organization` and `organization_linkedin_url`.
 
 ## Find User by Name and Keywords
 

--- a/tests/test_extract_companies_from_image.py
+++ b/tests/test_extract_companies_from_image.py
@@ -13,11 +13,12 @@ class DummyClient:
         self.kwargs = kwargs
         return SimpleNamespace(output_text='["Acme"]')
 
-async def fake_details(name, location=None):
+async def fake_details(name, location=None, organization_linkedin_url="", organization_website=""):
     return {
-        "company_website": "https://acme.com",
-        "company_domain": "acme.com",
-        "linkedin_url": "https://www.linkedin.com/company/acme",
+        "organization_name": name,
+        "organization_website": "https://acme.com",
+        "primary_domain_of_organization": "acme.com",
+        "organization_linkedin_url": "https://www.linkedin.com/company/acme",
     }
 
 
@@ -31,6 +32,7 @@ def test_main(monkeypatch, tmp_path, capsys):
     mod.main()
     captured = capsys.readouterr()
     data = json.loads(captured.out)
-    assert data[0]["company_name"] == "Acme"
-    assert data[0]["company_domain"] == "acme.com"
+    assert data[0]["organization_name"] == "Acme"
+    assert data[0]["primary_domain_of_organization"] == "acme.com"
     assert dummy.kwargs["input"][0]["content"][1]["image_url"] == "http://e.com/logo.png"
+

--- a/tests/test_find_company_info.py
+++ b/tests/test_find_company_info.py
@@ -1,4 +1,5 @@
 import asyncio
+import csv
 from utils import find_company_info as mod
 
 async def fake_search(query: str, *args, **kwargs):
@@ -13,7 +14,27 @@ def test_find_company_details(monkeypatch):
     monkeypatch.setattr(mod, "search_google_serper", fake_search)
     monkeypatch.setattr(mod, "get_external_links", fake_get_external_links)
     result = asyncio.run(mod.find_company_details("Foo"))
-    assert result["linkedin_url"] == "https://www.linkedin.com/company/foo"
-    assert result["company_website"] == "https://foo.com/"
-    assert result["company_domain"] == "foo.com"
+    assert result["organization_linkedin_url"] == "https://www.linkedin.com/company/foo"
+    assert result["organization_website"] == "https://foo.com/"
+    assert result["primary_domain_of_organization"] == "foo.com"
+
+
+async def fake_details(name, location=None, organization_linkedin_url="", organization_website=""):
+    return {
+        "organization_name": name,
+        "organization_website": "https://foo.com/",
+        "primary_domain_of_organization": "foo.com",
+        "organization_linkedin_url": "https://www.linkedin.com/company/foo",
+    }
+
+
+def test_find_company_info_from_csv(tmp_path, monkeypatch):
+    in_file = tmp_path / "in.csv"
+    in_file.write_text("organization_name\nFoo\n")
+    out_file = tmp_path / "out.csv"
+    monkeypatch.setattr(mod, "find_company_details", fake_details)
+    mod.find_company_info_from_csv(in_file, out_file)
+    rows = list(csv.DictReader(out_file.open()))
+    assert rows[0]["organization_linkedin_url"].endswith("/foo")
+
 


### PR DESCRIPTION
## Summary
- expand `find_company_info` to accept organization name, LinkedIn URL or website
- add CSV batch mode for company info lookup
- update app parameters for new inputs
- adjust utilities and docs for new output field names
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e77b6cde0832d9a29d665eff4be0b