### PR TITLE
Update CSV help for Find Company Info

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -109,7 +109,7 @@
           {% endif %}
         </div>
         <div class="mb-3" id="file-container" style="display:none;">
-          <label class="form-label">Upload CSV (must include <code>website_url</code> column)</label>
+          <label class="form-label" id="csv-help">Upload CSV (must include <code>website_url</code> column)</label>
           <input class="form-control" type="file" name="csv_file">
         </div>
         <div id="params-container"></div>
@@ -232,7 +232,12 @@
 {% block scripts %}
 <script>
   const PARAM_MAP = {{ util_params|tojson|safe }};
-    const UPLOAD_ONLY_UTILS = {{ upload_only|tojson }};
+  const UPLOAD_ONLY_UTILS = {{ upload_only|tojson }};
+  const CSV_HELP = {
+    default: 'Upload CSV (must include <code>website_url</code> column)',
+    find_company_info:
+      'Upload CSV (must include <code>organization_name</code>, <code>organization_linkedin_url</code> or <code>organization_website</code> column)'
+  };
   const utilInput = document.getElementById('util-name-input');
 
       function selectUtil(name) {
@@ -305,6 +310,10 @@
         }
         const mode = isUploadOnly ? 'file' : document.querySelector('input[name="input_mode"]:checked').value;
         document.getElementById('file-container').style.display = mode === 'file' ? '' : 'none';
+        const helpEl = document.getElementById('csv-help');
+        if (helpEl) {
+          helpEl.innerHTML = CSV_HELP[util] || CSV_HELP.default;
+        }
         const paramsVisible = !(
           ['file', 'previous'].includes(mode) &&
           !['call_openai_llm', 'score_lead', 'extract_from_webpage'].includes(util)

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -59,6 +59,10 @@ task run:command -- find_company_info --organization_name "Dhisana" --location "
 
 The script prints JSON with `organization_name`, `organization_website`, `primary_domain_of_organization` and `organization_linkedin_url`.
 
+You can also upload a CSV containing an `organization_name`, `organization_linkedin_url`
+or `organization_website` column to look up multiple companies at once. The processed
+results will be written to a CSV file for download in the web interface.
+
 ## Find User by Name and Keywords
 
 `find_a_user_by_name_and_keywords.py` searches Google via Serper.dev for a person's LinkedIn profile. Provide the person's full name and optional additional keywords. The script outputs a JSON object with lead details parsed from the search results, including the LinkedIn profile URL.


### PR DESCRIPTION
## Summary
- update the CSV upload label so the Find Company Info tool instructs users to provide `organization_name`, `organization_linkedin_url` or `organization_website` columns
- document CSV support for `find_company_info.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e79a0fad0832d9b887f2893073b21