### PR TITLE
Add Apollo people search utility

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -274,9 +274,37 @@
           return;
         }
         const div = document.createElement('div');
-        const input = document.createElement('input');
         const label = document.createElement('label');
         label.textContent = p.label;
+        let input;
+        if (p.type === 'boolean') {
+          div.className = 'form-check mb-3';
+          input = document.createElement('input');
+          input.type = 'checkbox';
+          input.className = 'form-check-input';
+          input.value = '1';
+          input.id = p.name;
+          label.className = 'form-check-label';
+          label.setAttribute('for', p.name);
+        } else if (p.choices) {
+          div.className = 'mb-3';
+          label.className = 'form-label';
+          input = document.createElement('select');
+          input.className = 'form-select';
+          if (p.multiple) input.multiple = true;
+          p.choices.forEach(optVal => {
+            const opt = document.createElement('option');
+            opt.value = optVal;
+            opt.textContent = optVal;
+            input.appendChild(opt);
+          });
+        } else {
+          div.className = 'mb-3';
+          label.className = 'form-label';
+          input = document.createElement('input');
+          input.type = 'text';
+          input.className = 'form-control';
+        }
         input.name = p.name;
         if (util === 'linkedin_search_to_csv' && p.name === '--num') {
           input.value = '10';
@@ -284,24 +312,8 @@
         if (util === 'linkedin_search_to_csv' && p.name === 'query') {
           input.value = 'site:linkedin.com/in "VP Sales" OR "Head of Sales"';
         }
-        if (p.type === 'boolean') {
-          div.className = 'form-check mb-3';
-          input.type = 'checkbox';
-          input.className = 'form-check-input';
-          input.value = '1';
-          input.id = p.name;
-          label.className = 'form-check-label';
-          label.setAttribute('for', p.name);
-          div.appendChild(input);
-          div.appendChild(label);
-        } else {
-          div.className = 'mb-3';
-          input.type = 'text';
-          input.className = 'form-control';
-          label.className = 'form-label';
-          div.appendChild(label);
-          div.appendChild(input);
-        }
+        div.appendChild(label);
+        div.appendChild(input);
         container.appendChild(div);
       });
     }

--- a/tests/test_apollo_people_search.py
+++ b/tests/test_apollo_people_search.py
@@ -1,0 +1,114 @@
+import csv
+import asyncio
+from utils import apollo_people_search as mod
+
+
+class DummyResp:
+    def __init__(self, data):
+        self.data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        return self.data
+
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, headers=None, json=None):
+        self.posts.append((url, json))
+        return DummyResp(self.data)
+
+
+class MultiSession:
+    def __init__(self, data_list):
+        self.data_list = data_list
+        self.posts = []
+        self.idx = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, headers=None, json=None):
+        data = self.data_list[min(self.idx, len(self.data_list) - 1)]
+        self.idx += 1
+        self.posts.append((url, json))
+        return DummyResp(data)
+
+
+def sample_payload():
+    return {
+        "contacts": [
+            {
+                "id": "1",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "linkedin_url": "https://linkedin.com/in/janedoe",
+                "email": "jane@example.com",
+                "title": "CEO",
+                "organization": {"name": "Acme", "primary_domain": "acme.com"},
+            }
+        ],
+        "pagination": {"page": 1, "per_page": 1, "total_entries": 1, "total_pages": 1},
+    }
+
+
+def test_apollo_people_search(monkeypatch):
+    data = sample_payload()
+    session = DummySession(data)
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(mod.asyncio, "sleep", lambda x: None)
+    monkeypatch.setenv("APOLLO_API_KEY", "x")
+    results = asyncio.run(mod.apollo_people_search(number_of_leads=1))
+    assert session.posts[0][0].endswith("/mixed_people/search")
+    assert results[0]["user_linkedin_url"] == "https://linkedin.com/in/janedoe"
+    assert results[0]["organization_name"] == "Acme"
+    assert results[0]["primary_domain_of_organization"] == "acme.com"
+
+
+def test_apollo_people_search_to_csv(tmp_path, monkeypatch):
+    data = sample_payload()
+    session = DummySession(data)
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setattr(mod.asyncio, "sleep", lambda x: None)
+    monkeypatch.setenv("APOLLO_API_KEY", "y")
+    out_file = tmp_path / "out.csv"
+    mod.apollo_people_search_to_csv(out_file, number_of_leads=1)
+    rows = list(csv.DictReader(out_file.open()))
+    assert rows[0]["user_linkedin_url"] == "https://linkedin.com/in/janedoe"
+
+
+def test_apollo_people_search_pagination(monkeypatch):
+    first = sample_payload()
+    first["pagination"]["total_pages"] = 2
+    second = sample_payload()
+    second["contacts"][0]["id"] = "2"
+    session = MultiSession([first, second])
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    sleeps = []
+
+    async def fake_sleep(x):
+        sleeps.append(x)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", fake_sleep)
+    monkeypatch.setenv("APOLLO_API_KEY", "z")
+    results = asyncio.run(mod.apollo_people_search(number_of_leads=2))
+    assert len(session.posts) == 2
+    assert sleeps == [10]
+    assert len(results) == 2

--- a/utils/apollo_people_search.py
+++ b/utils/apollo_people_search.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import aiohttp
+
+from utils.apollo_info import fill_in_properties_with_preference
+
+API_BASE = "https://api.apollo.io/api/v1"
+
+
+async def _search_page(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Call the Apollo.io people search endpoint and return JSON."""
+    api_key = os.getenv("APOLLO_API_KEY")
+    if not api_key:
+        raise RuntimeError("APOLLO_API_KEY environment variable is not set")
+
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
+    url = f"{API_BASE}/mixed_people/search"
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, headers=headers, json=params) as resp:
+            return await resp.json()
+
+
+def _add_extra_fields(base: Dict[str, Any], contact: Dict[str, Any]) -> Dict[str, Any]:
+    """Return mapping of contact data flattened into ``base`` dict."""
+    for key, value in contact.items():
+        if key in base:
+            continue
+        if isinstance(value, (dict, list)):
+            base[key] = json.dumps(value)
+        else:
+            base[key] = value
+    return base
+
+
+async def apollo_people_search(number_of_leads: int = 10, **params: Any) -> List[Dict[str, Any]]:
+    """Search Apollo people and return a list of mapped dictionaries."""
+    per_page = 100 if number_of_leads > 10 else number_of_leads
+    page = 1
+    results: List[Dict[str, Any]] = []
+
+    while len(results) < number_of_leads:
+        payload = dict(params)
+        payload.update({"page": page, "per_page": per_page})
+        data = await _search_page(payload)
+        contacts = data.get("contacts") or []
+        for contact in contacts:
+            mapped = fill_in_properties_with_preference({}, contact)
+            mapped = _add_extra_fields(mapped, contact)
+            results.append(mapped)
+            if len(results) >= number_of_leads:
+                break
+        pagination = data.get("pagination") or {}
+        total_pages = pagination.get("total_pages", page)
+        if page >= total_pages or not contacts:
+            break
+        page += 1
+        if len(results) < number_of_leads:
+            await asyncio.sleep(10)
+    return results[:number_of_leads]
+
+
+def apollo_people_search_to_csv(output_file: str | Path, **params: Any) -> None:
+    """Run ``apollo_people_search`` and write the results to ``output_file``."""
+    out_path = Path(output_file)
+    results = asyncio.run(apollo_people_search(**params))
+    fieldnames: List[str] = []
+    for row in results:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+
+    with out_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+
+
+def _parse_list(value: str) -> List[str]:
+    value = value.strip()
+    if not value:
+        return []
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search people in Apollo.io")
+    parser.add_argument("output_file", help="CSV file to create")
+    parser.add_argument("--person_titles", default="", help="Comma separated job titles")
+    parser.add_argument("--person_locations", default="", help="Comma separated locations")
+    parser.add_argument("--person_seniorities", default="", help="Comma separated seniorities")
+    parser.add_argument("--organization_locations", default="", help="Comma separated organization HQ locations")
+    parser.add_argument("--organization_domains", default="", help="Comma separated organization domains")
+    parser.add_argument("--include_similar_titles", action="store_true", default=False, help="Include similar titles")
+    parser.add_argument("--contact_email_status", default="", help="Comma separated email statuses")
+    parser.add_argument("--organization_ids", default="", help="Comma separated organization IDs")
+    parser.add_argument("--organization_num_employees_ranges", default="", help="Comma separated employee ranges like 1,10")
+    parser.add_argument("--q_keywords", default="", help="Keyword filter")
+    parser.add_argument("--num_leads", type=int, default=10, help="Number of leads to fetch")
+    args = parser.parse_args()
+
+    params = {
+        "person_titles": _parse_list(args.person_titles),
+        "person_locations": _parse_list(args.person_locations),
+        "person_seniorities": _parse_list(args.person_seniorities),
+        "organization_locations": _parse_list(args.organization_locations),
+        "q_organization_domains_list": _parse_list(args.organization_domains),
+        "include_similar_titles": args.include_similar_titles,
+        "contact_email_status": _parse_list(args.contact_email_status),
+        "organization_ids": _parse_list(args.organization_ids),
+        "organization_num_employees_ranges": _parse_list(args.organization_num_employees_ranges),
+        "q_keywords": args.q_keywords,
+        "number_of_leads": args.num_leads,
+    }
+
+    apollo_people_search_to_csv(args.output_file, **params)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add apollo people search module
- integrate with app
- render drop-down parameters in UI
- test pagination and CSV output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fc5b59660832d9a3f7d9092cbb2ab