### PR TITLE
Improve Apollo people search UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -292,6 +292,17 @@ UTILITY_PARAMETERS = {
         {
             "name": "--organization_num_employees_ranges",
             "label": "Employee ranges",
+            "choices": [
+                "1-10",
+                "11-50",
+                "51-200",
+                "201-500",
+                "501-1000",
+                "1001-5000",
+                "5001-10000",
+                "10001+",
+            ],
+            "multiple": True,
         },
         {"name": "--q_keywords", "label": "Keyword filter"},
         {"name": "--num_leads", "label": "Number of leads"},
@@ -600,6 +611,9 @@ def run_utility():
                 ):
                     cmd.append("--leads")
                 cmd.extend(["--output_csv", out_path])
+            elif util_name == "apollo_people_search":
+                out_path = common.make_temp_csv_filename(util_name)
+                cmd.insert(3, out_path)
             return cmd
 
         def run_cmd(cmd: list[str], show_ux: bool = False) -> tuple[str, str, str]:

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -269,6 +269,7 @@
       const util = utilInput.value;
       const params = PARAM_MAP[util] || [];
       const mode = document.querySelector('input[name="input_mode"]:checked')?.value || 'single';
+      let apolloTitleDiv = null;
       params.forEach(p => {
         if (util === 'extract_from_webpage' && mode === 'file' && p.name === 'url') {
           return;
@@ -309,12 +310,28 @@
         if (util === 'linkedin_search_to_csv' && p.name === '--num') {
           input.value = '10';
         }
+        if (util === 'apollo_people_search' && p.name === '--num_leads') {
+          input.value = '10';
+        }
         if (util === 'linkedin_search_to_csv' && p.name === 'query') {
           input.value = 'site:linkedin.com/in "VP Sales" OR "Head of Sales"';
         }
-        div.appendChild(label);
-        div.appendChild(input);
-        container.appendChild(div);
+        if (util === 'apollo_people_search' && p.name === '--include_similar_titles' && apolloTitleDiv) {
+          const checkDiv = document.createElement('div');
+          checkDiv.className = 'form-check form-check-inline ms-2';
+          input.className = 'form-check-input';
+          label.className = 'form-check-label ms-1';
+          checkDiv.appendChild(input);
+          checkDiv.appendChild(label);
+          apolloTitleDiv.appendChild(checkDiv);
+        } else {
+          div.appendChild(label);
+          div.appendChild(input);
+          container.appendChild(div);
+          if (util === 'apollo_people_search' && p.name === '--person_titles') {
+            apolloTitleDiv = div;
+          }
+        }
       });
     }
 

--- a/utils/apollo_people_search.py
+++ b/utils/apollo_people_search.py
@@ -1,3 +1,5 @@
+"""Search and export leads using Apollo.io people search."""
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- show friendly description for Apollo people search
- allow selecting employee ranges and keep seniority multi-select
- default number of leads to 10
- render "include similar titles" checkbox next to job titles
- auto-generate CSV output path when running Apollo people search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcd09c778832d827141b700f8cf23