### PR TITLE
Add LinkedIn support for findymail

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ from utils import (
     find_users_by_name_and_keywords,
     find_user_by_job_title,
     find_company_info,
+    find_contact_with_findymail,
     call_openai_llm,
     score_lead,
     generate_email,
@@ -202,7 +203,8 @@ UTILITY_PARAMETERS = {
     ],
     "find_contact_with_findymail": [
         {"name": "full_name", "label": "Full name"},
-        {"name": "company_domain", "label": "Company domain"},
+        {"name": "primary_domain_of_organization", "label": "Company domain"},
+        {"name": "--linkedin_url", "label": "LinkedIn URL"},
     ],
     "find_user_by_job_title": [
         {"name": "job_title", "label": "Job title"},
@@ -785,6 +787,20 @@ def run_utility():
                 out_path = common.make_temp_csv_filename(util_name)
                 try:
                     find_company_info.find_company_info_from_csv(uploaded, out_path)
+                    download_name = out_path
+                    output_csv_path = out_path
+                    util_output = None
+                except Exception as exc:
+                    util_output = f"Error: {exc}"
+                    download_name = None
+                    output_csv_path = None
+            elif util_name == "find_contact_with_findymail":
+                out_path = common.make_temp_csv_filename(util_name)
+                try:
+                    find_contact_with_findymail.find_contact_with_findymail_from_csv(
+                        uploaded,
+                        out_path,
+                    )
                     download_name = out_path
                     output_csv_path = out_path
                     util_output = None

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -127,13 +127,18 @@ The resulting CSV includes columns for the parsed lead details
 ## Find Email and Phone
 
 `find_contact_with_findymail.py` queries the Findymail API for a person's
-e-mail address and phone number using their full name and company domain.
-Set the `FINDYMAIL_API_KEY` environment variable before running the script.
+e-mail address and phone number. Provide a LinkedIn profile URL when
+available, otherwise supply the person's full name and
+`primary_domain_of_organization`. Set the `FINDYMAIL_API_KEY` environment
+variable before running the script.
 
-Run it with the name and domain:
+Run it with a name and domain or with a LinkedIn URL:
 
 ```bash
+# using name and company domain
 task run:command -- find_contact_with_findymail "Jane Doe" example.com
+# or using a LinkedIn profile
+task run:command -- find_contact_with_findymail "Jane Doe" --linkedin_url https://linkedin.com/in/janedoe
 ```
 
 The script prints a JSON object containing `email`, `phone` and the raw

--- a/tests/test_find_contact_with_findymail.py
+++ b/tests/test_find_contact_with_findymail.py
@@ -1,4 +1,5 @@
 import asyncio
+import csv
 import pytest
 from utils import find_contact_with_findymail as mod
 
@@ -34,19 +35,54 @@ class DummySession:
         return DummyResp(self.data)
 
 
-def test_find_email_and_phone(monkeypatch):
+def test_find_email_and_phone_by_linkedin(monkeypatch):
     data = {"contact": {"email": "e@x.com", "phoneNumbers": ["123"]}}
     session = DummySession(data)
     monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
     monkeypatch.setenv("FINDYMAIL_API_KEY", "key")
-    result = asyncio.run(mod.find_email_and_phone("John Doe", "example.com"))
-    assert session.posts[0][0].endswith("/search/name")
+    result = asyncio.run(
+        mod.find_email_and_phone(
+            "John Doe",
+            "example.com",
+            linkedin_url="https://linkedin.com/in/foo",
+        )
+    )
+    assert session.posts[0][0].endswith("/search/linkedin")
     assert result["email"] == "e@x.com"
     assert result["phone"] == "123"
+
+
+def test_find_email_and_phone_by_name(monkeypatch):
+    data = {"contact": {"email": "e@x.com"}}
+    session = DummySession(data)
+    monkeypatch.setattr(mod.aiohttp, "ClientSession", lambda: session)
+    monkeypatch.setenv("FINDYMAIL_API_KEY", "key")
+    result = asyncio.run(
+        mod.find_email_and_phone("John Doe", "example.com")
+    )
+    assert session.posts[0][0].endswith("/search/name")
+    assert result["email"] == "e@x.com"
 
 
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("FINDYMAIL_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         asyncio.run(mod.find_email_and_phone("A", "b.com"))
+
+
+async def fake_find_email_and_phone(full_name="", domain="", linkedin_url=""):
+    return {"email": "e@x.com", "phone": "123", "contact_info": "{}"}
+
+
+def test_from_csv(tmp_path, monkeypatch):
+    in_file = tmp_path / "in.csv"
+    in_file.write_text(
+        "full_name,linkedin_url,primary_domain_of_organization\n"
+        "John Doe,https://linkedin.com/in/johndoe,example.com\n"
+    )
+    out_file = tmp_path / "out.csv"
+    monkeypatch.setattr(mod, "find_email_and_phone", fake_find_email_and_phone)
+    mod.find_contact_with_findymail_from_csv(in_file, out_file)
+    rows = list(csv.DictReader(out_file.open()))
+    assert rows[0]["email"] == "e@x.com"
 

--- a/utils/find_contact_with_findymail.py
+++ b/utils/find_contact_with_findymail.py
@@ -8,6 +8,8 @@ import json
 import logging
 import os
 from typing import Any, Dict
+from pathlib import Path
+import csv
 
 import aiohttp
 
@@ -17,18 +19,37 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-async def find_email_and_phone(full_name: str, domain: str) -> Dict[str, Any]:
-    """Return e-mail and phone number for ``full_name`` at ``domain``."""
+async def find_email_and_phone(
+    full_name: str = "",
+    primary_domain_of_organization: str = "",
+    linkedin_url: str = "",
+) -> Dict[str, Any]:
+    """Return e-mail and phone number for a lead.
+
+    If ``linkedin_url`` is provided it is used to query Findymail directly.
+    Otherwise ``full_name`` together with ``primary_domain_of_organization`` is
+    used.
+    """
     api_key = os.getenv("FINDYMAIL_API_KEY")
     if not api_key:
         raise RuntimeError("FINDYMAIL_API_KEY environment variable is not set")
 
-    if not full_name or not domain:
+    if not linkedin_url and not (full_name and primary_domain_of_organization):
         return {"email": "", "phone": "", "contact_info": ""}
 
-    url = f"{API_BASE}/search/name"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-    payload = {"name": full_name, "domain": domain}
+    if linkedin_url:
+        url = f"{API_BASE}/search/linkedin"
+        payload = {"linkedin_url": linkedin_url}
+    else:
+        url = f"{API_BASE}/search/name"
+        payload = {
+            "name": full_name,
+            "domain": primary_domain_of_organization,
+        }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
 
     async with aiohttp.ClientSession() as session:
         async with session.post(url, headers=headers, json=payload) as resp:
@@ -60,15 +81,70 @@ async def find_email_and_phone(full_name: str, domain: str) -> Dict[str, Any]:
     }
 
 
+def find_contact_with_findymail_from_csv(
+    input_file: str | Path, output_file: str | Path
+) -> None:
+    """Look up contact details for each row of ``input_file`` and write results."""
+
+    in_path = Path(input_file)
+    out_path = Path(output_file)
+
+    with in_path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+
+    if "full_name" not in fieldnames:
+        raise ValueError("upload csv with full_name column")
+
+    extra_fields = ["email", "phone", "contact_info"]
+    out_fields = list(fieldnames)
+    for f in extra_fields:
+        if f not in out_fields:
+            out_fields.append(f)
+
+    processed: list[dict[str, str]] = []
+    for row in rows:
+        linkedin_url = (row.get("linkedin_url") or row.get("user_linkedin_url") or "").strip()
+        domain = (
+            row.get("primary_domain_of_organization")
+            or row.get("company_domain")
+            or ""
+        ).strip()
+        result = asyncio.run(
+            find_email_and_phone(row.get("full_name", ""), domain, linkedin_url)
+        )
+        row.update(result)
+        processed.append(row)
+
+    with out_path.open("w", newline="", encoding="utf-8") as out_fh:
+        writer = csv.DictWriter(out_fh, fieldnames=out_fields)
+        writer.writeheader()
+        for row in processed:
+            writer.writerow(row)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Find a person's e-mail and phone number using Findymail"
     )
     parser.add_argument("full_name", help="Person's full name")
-    parser.add_argument("company_domain", help="Company domain")
+    parser.add_argument(
+        "primary_domain_of_organization",
+        nargs="?",
+        default="",
+        help="Company domain",
+    )
+    parser.add_argument("--linkedin_url", default="", help="LinkedIn profile URL")
     args = parser.parse_args()
 
-    result = asyncio.run(find_email_and_phone(args.full_name, args.company_domain))
+    result = asyncio.run(
+        find_email_and_phone(
+            args.full_name,
+            args.primary_domain_of_organization,
+            args.linkedin_url,
+        )
+    )
     print(json.dumps(result, indent=2))
 
 


### PR DESCRIPTION
## Summary
- support LinkedIn URL search in `find_contact_with_findymail`
- rename domain argument to `primary_domain_of_organization`
- add CSV helper for bulk lookups
- wire the new behaviour in the web app
- document new usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd897c314832d89ff41f5a0d69a87