### PR TITLE
Add Apollo org keyword tags param

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -306,6 +306,7 @@ UTILITY_PARAMETERS = {
             ],
             "multiple": True,
         },
+        {"name": "--q_organization_keyword_tags", "label": "Organization keyword tags"},
         {"name": "--q_keywords", "label": "Keyword filter"},
         {"name": "--num_leads", "label": "Number of leads"},
     ],

--- a/tests/test_apollo_people_search.py
+++ b/tests/test_apollo_people_search.py
@@ -127,6 +127,7 @@ def test_clean_payload_removes_empty():
     payload = {
         "person_titles": [],
         "q_keywords": "CEO",
+        "q_organization_keyword_tags": ["semiconductor manufacturing"],
         "include_similar_titles": False,
         "page": 1,
     }
@@ -134,6 +135,7 @@ def test_clean_payload_removes_empty():
     assert "person_titles" not in cleaned
     assert "include_similar_titles" not in cleaned
     assert cleaned["q_keywords"] == "CEO"
+    assert cleaned["q_organization_keyword_tags"] == ["semiconductor manufacturing"]
 
 
 def test_apollo_people_results(monkeypatch):

--- a/utils/apollo_people_search.py
+++ b/utils/apollo_people_search.py
@@ -146,6 +146,7 @@ def main() -> None:
     parser.add_argument("--contact_email_status", default="", help="Comma separated email statuses")
     parser.add_argument("--organization_ids", default="", help="Comma separated organization IDs")
     parser.add_argument("--organization_num_employees_ranges", default="", help="Comma separated employee ranges like 1,10")
+    parser.add_argument("--q_organization_keyword_tags", default="", help="Comma separated organization keyword tags")
     parser.add_argument("--q_keywords", default="", help="Keyword filter")
     parser.add_argument("--num_leads", type=int, default=10, help="Number of leads to fetch")
     args = parser.parse_args()
@@ -160,6 +161,7 @@ def main() -> None:
         "contact_email_status": _parse_list(args.contact_email_status),
         "organization_ids": _parse_list(args.organization_ids),
         "organization_num_employees_ranges": _parse_list(args.organization_num_employees_ranges),
+        "q_organization_keyword_tags": _parse_list(args.q_organization_keyword_tags),
         "q_keywords": args.q_keywords,
         "number_of_leads": args.num_leads,
     }


### PR DESCRIPTION
## Summary
- support `q_organization_keyword_tags` in the Apollo search utility
- expose the new parameter in the web app
- test cleaning behavior of the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff7e44cac832dafa2814872d2093a