### PR TITLE
Improve custom utility creation workflow

### DIFF
--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -358,7 +358,8 @@
         if (helpEl) {
           helpEl.innerHTML = CSV_HELP[util] || CSV_HELP.default;
         }
-        const paramsVisible = !(
+        const params = PARAM_MAP[util] || [];
+        const paramsVisible = params.length > 0 && !(
           ['file', 'previous'].includes(mode) &&
           !['call_openai_llm', 'score_lead', 'extract_from_webpage', 'find_user_by_job_title'].includes(util)
         );


### PR DESCRIPTION
## Summary
- load CLI parameter info from user utility metadata
- update prompt when generating a new utility
- store argument metadata when saving a new utility
- refresh parameters after saving
- hide parameter section when no parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850de7e104c832d94cda79c5758cb61