### PR TITLE
Support row-level params for job title search CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ download link will be displayed. Plain text output is shown in the page.
 - [LinkedIn Search to CSV](docs/utils_usage.md#search-linkedin-urls) – gather LinkedIn profile URLs from Google.
 - [Find Company Info](docs/utils_usage.md#find-company-info) – discover a company's website and LinkedIn page.
 - [Find LinkedIn Profile by Name](docs/utils_usage.md#find-user-by-name-and-keywords) – look up a profile using a name and keywords.
-- [Find LinkedIn Profile by Job Title](docs/utils_usage.md#find-user-by-job-title-and-company) – search by title at a target company.
+- [Find LinkedIn Profile by Job Title](docs/utils_usage.md#find-user-by-job-title-and-organization) – search by title at a target organization.
 - [Bulk Find LinkedIn Profiles](docs/utils_usage.md#find-users-by-name-and-keywords) – process a CSV of names to find profiles.
 - [Find Email and Phone](docs/utils_usage.md#find-email-and-phone) – retrieve contact details with Findymail.
 - [Push Lead to Dhisana](docs/utils_usage.md#push-lead-to-dhisana-webhook) – send lead data to Dhisana for enrichment.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -209,7 +209,7 @@ UTILITY_PARAMETERS = {
     ],
     "find_user_by_job_title": [
         {"name": "job_title", "label": "Job title"},
-        {"name": "company_name", "label": "Company name"},
+        {"name": "organization_name", "label": "Organization name"},
         {"name": "search_keywords", "label": "Search keywords"},
     ],
     "find_users_by_name_and_keywords": [],
@@ -860,8 +860,6 @@ def run_utility():
                     find_user_by_job_title.find_user_by_job_title_from_csv(
                         uploaded,
                         out_path,
-                        job_title=request.form.get("job_title", ""),
-                        search_keywords=request.form.get("search_keywords", ""),
                     )
                     download_name = out_path
                     output_csv_path = out_path

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -360,7 +360,7 @@
         const params = (PARAM_MAP[util] || []).filter(p => !['output_file','--output_file','input_file','--input_file','csv_file','--csv_file'].includes(p.name));
         const paramsVisible = params.length > 0 && !(
           ['file', 'previous'].includes(mode) &&
-          !['call_openai_llm', 'score_lead', 'extract_from_webpage', 'find_user_by_job_title'].includes(util)
+          !['call_openai_llm', 'score_lead', 'extract_from_webpage'].includes(util)
         );
         document.getElementById('params-container').style.display = paramsVisible ? '' : 'none';
         renderParams();

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -77,14 +77,14 @@ task run:command -- find_a_user_by_name_and_keywords \
 
 The script prints the resulting JSON to stdout.
 
-## Find User by Job Title and Company
+## Find User by Job Title and Organization
 
 `find_user_by_job_title.py` searches Google via Serper.dev for a LinkedIn profile
-matching a specific job title at a company. Provide the job title, the company
-name and optional extra keywords. The returned profile URL is normalized to the
+matching a specific job title at an organization. Provide the job title, the
+organization name and optional extra keywords. The returned profile URL is normalized to the
 `https://www.linkedin.com/in/<id>` format.
 
-Run it with a title, company and keywords:
+Run it with a title, organization and keywords:
 
 ```bash
 task run:command -- find_user_by_job_title \

--- a/tests/test_find_by_job_title_csv.py
+++ b/tests/test_find_by_job_title_csv.py
@@ -2,22 +2,36 @@ import csv
 from pathlib import Path
 from utils import find_user_by_job_title as mod
 
-async def fake_find(job_title: str, company_name: str, search_keywords: str = "", exclude_profiles_intitle: bool = False):
-    return f"https://www.linkedin.com/in/{company_name.lower()}-{job_title.lower()}"
+async def fake_find(job_title: str, organization_name: str, search_keywords: str = "", exclude_profiles_intitle: bool = False):
+    return f"https://www.linkedin.com/in/{organization_name.lower()}-{job_title.lower()}"
 
 def test_find_user_by_job_title_from_csv(tmp_path, monkeypatch):
     in_file = tmp_path / "in.csv"
     with in_file.open("w", newline="", encoding="utf-8") as fh:
-        writer = csv.DictWriter(fh, fieldnames=["organization_name"])
+        writer = csv.DictWriter(
+            fh, fieldnames=["job_title", "organization_name", "search_keywords"]
+        )
         writer.writeheader()
-        writer.writerow({"organization_name": "Acme"})
-        writer.writerow({"organization_name": "Acme"})
-        writer.writerow({"organization_name": "Beta"})
+        writer.writerow({
+            "job_title": "CEO",
+            "organization_name": "Acme",
+            "search_keywords": "sales",
+        })
+        writer.writerow({
+            "job_title": "CEO",
+            "organization_name": "Acme",
+            "search_keywords": "sales",
+        })
+        writer.writerow({
+            "job_title": "CTO",
+            "organization_name": "Beta",
+            "search_keywords": "",
+        })
     out_file = tmp_path / "out.csv"
     monkeypatch.setattr(mod, "find_user_linkedin_url_by_job_title", fake_find)
-    mod.find_user_by_job_title_from_csv(in_file, out_file, job_title="CEO", search_keywords="sales")
+    mod.find_user_by_job_title_from_csv(in_file, out_file)
     rows = list(csv.DictReader(out_file.open()))
     assert len(rows) == 2
-    assert rows[0]["company_name"] == "Acme"
+    assert rows[0]["organization_name"] == "Acme"
     assert rows[0]["job_title"] == "CEO"
     assert rows[0]["user_linkedin_url"].endswith("acme-ceo")


### PR DESCRIPTION
## Summary
- rename `company_name` argument to `organization_name`
- parse `job_title`, `organization_name`, and `search_keywords` from CSV rows
- hide form fields for the upload mode
- adjust docs and readme wording for organization naming
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517b807808832db657698ce8bf00c0