### PR TITLE
Update lead extraction docs and Playwright logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ download link will be displayed. Plain text output is shown in the page.
 - [Update Salesforce Contact](docs/utils_usage.md#update-salesforce-contact) – modify contact fields.
 - [Add Salesforce Note](docs/utils_usage.md#add-salesforce-note) – attach a note to a contact.
 - [Scrape Website HTML (Playwright)](utils/fetch_html_playwright.py) – scrape page HTML for lead extraction.
-- [Extract Leads From Website](utils/extract_from_webpage.py) – pull leads and companies from any website. You can provide natural language actions for page navigation and parsing with options like `--initial_actions` and `--pagination_actions`. Use `--show_ux` to run Playwright with a visible browser.
+- [scrape and extract leads from website](utils/extract_from_webpage.py) – scrape any web page with Playwright and extract companies or leads listed. Provide Brightdata proxy and 2captcha API keys for stealth mode. You can supply natural language actions for navigation with `--initial_actions` and `--pagination_actions`. Use `--show_ux` to see the browser.
 - [Push Leads to Dhisana](docs/push_leads_to_dhisana.md) – send scraped LinkedIn URLs to Dhisana for enrichment and outreach.
 - [Create Dhisana Webhook](docs/create_dhisana_webhook.md) – configure your webhook and API key.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -84,7 +84,7 @@ UTILITY_TITLES = {
     "apollo_info": "Enrich Lead With Apollo.io",
     "fetch_html_playwright": "Scrape Website HTML (Playwright)",
     "extract_companies_from_image": "Extract Companies from Image",
-    "extract_from_webpage": "Extract Leads From Website",
+    "extract_from_webpage": "scrape and extract leads from website",
     "generate_image": "Generate Image",
     "get_website_information": "Get website information",
     "score_lead": "Score Leads",

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -391,11 +391,13 @@ the `OPENAI_API_KEY` in the environment variables.
 task run:command -- get_website_information http://example.com/ "what is the main color of the website?"
 ```
 
-## Extract Leads From Website
+## scrape and extract leads from website
 
-`extract_from_webpage.py` scrapes a page with Playwright and uses an LLM to
-parse leads or organizations from the text. Provide the starting URL and use
-`--lead` or `--leads` to control how many leads are returned. You can run custom
+`extract_from_webpage.py` scrapes any webpage with Playwright and pulls out
+companies or leads mentioned on the page. Set your Brightdata proxy URL in
+`PROXY_URL` and a 2Captcha key in `TWO_CAPTCHA_API_KEY` to operate in stealth
+mode. Provide the starting URL and use `--lead` or `--leads` to control how many
+leads are returned. You can run custom
 JavaScript on the initial page load, on each page load and for pagination by
 supplying natural language instructions with `--initial_actions`,
 `--page_actions` and `--pagination_actions`. Parsing behaviour can be tweaked


### PR DESCRIPTION
## Summary
- rename "Extract Leads From Website" tool to "scrape and extract leads from website"
- document using Brightdata proxy and 2Captcha for stealth scraping
- enhance Playwright HTML fetch logging
- ensure app mapping uses new tool name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565d4fec3c832d86e6122bbe036b4e