### PR TITLE
Remove editing from settings page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -982,15 +982,10 @@ def run_utility():
     )
 
 
-@app.route("/settings", methods=["GET", "POST"])
+@app.route("/settings")
 def settings():
+    """Display environment variables without allowing edits."""
     env_vars = load_env()
-    if request.method == "POST":
-        for key in env_vars:
-            value = request.form.get(key, "")
-            set_key(ENV_FILE, key, value)
-        flash("Settings saved.")
-        return redirect(url_for("settings"))
     return render_template("settings.html", env_vars=env_vars)
 
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -12,20 +12,17 @@
   {% endwith %}
 
   <h2>Settings</h2>
-  <form method="post">
-    {% for key, value in env_vars.items() %}
-      <div class="mb-3">
-        <label class="form-label" for="{{ key }}">{{ key }}</label>
-        <div class="input-group">
-          <input class="form-control" type="password" id="{{ key }}" name="{{ key }}" value="{{ value }}">
-          <button class="btn btn-outline-secondary toggle-password" type="button" data-target="{{ key }}">
-            <i class="bi bi-eye"></i>
-          </button>
-        </div>
+  {% for key, value in env_vars.items() %}
+    <div class="mb-3">
+      <label class="form-label" for="{{ key }}">{{ key }}</label>
+      <div class="input-group">
+        <input class="form-control" type="password" id="{{ key }}" value="{{ value }}" readonly>
+        <button class="btn btn-outline-secondary toggle-password" type="button" data-target="{{ key }}">
+          <i class="bi bi-eye"></i>
+        </button>
       </div>
-    {% endfor %}
-    <button class="btn btn-primary" type="submit">Save</button>
-  </form>
+    </div>
+  {% endfor %}
 
   <script>
     document.querySelectorAll('.toggle-password').forEach(function(btn) {


### PR DESCRIPTION
## Summary
- make settings page read-only by removing POST handler
- render env vars without an edit form or save button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566ec41eb8832dad3f8c6cae5fb412