### PR TITLE
Add guide for scraping links with ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ download link will be displayed. Plain text output is shown in the page.
 ## Scrape Content Hacks
 
 - [Scrape LinkedIn Commenters](docs/scrape_linkedin_commenters.md) – grab profile URLs from anyone commenting on a post.
+- [Scrape any page with ChatGPT](docs/scrape_links_with_chatgpt.md) – generate a quick console script to collect links from a website.
 
 ## Next Workitems in Roadmap:
 

--- a/docs/scrape_links_with_chatgpt.md
+++ b/docs/scrape_links_with_chatgpt.md
@@ -1,0 +1,33 @@
+# Scrape Any Web Page Using ChatGPT
+
+ChatGPT can generate quick JavaScript snippets that you paste into the Chrome console to collect links or other text from a page. After downloading the results you can enrich them with Dhisana AI.
+
+## Example: gather commenters from a LinkedIn post
+
+1. Open the LinkedIn post in Chrome.
+2. Right‑click the page and choose **Inspect** to view the HTML.
+3. Paste the prompt below into ChatGPT to generate the script.
+
+```
+Give me a standalone javascript that does the following which I can copy paste into chrome console.
+This javascript
+1. Finds all the linkedin urls of the format linkedin.com/in* in the page and creates a list
+2. finds if there is a button with text Load more comments inside the same. Then click on the button
+<button id="ember1968" class="comments-comments-list__load-more-comments-button--cr artdeco-button artdeco-button--muted artdeco-button--1 artdeco-button--tertiary ember-view"><!---->
+<span class="artdeco-button__text">
+    Load more comments
+</span></button>
+3. Do step 1 to find the linkedin urls then de-dup and add to the list. have all the linkedin user urls normalized to https://www.linkedin.com/in/<id>
+4. Do step 2 & 2 max of 30 times with a delay of 30 seconds between each load. stop if there is no more load more comments found.
+
+Take all the user_linkedin_urls aggregated so far and trigger the download of it as a csv file for download.
+Give me a js i can copy paste into chrome console for above.
+I am basically trying to find all users who have commented on a post.
+```
+
+4. Copy the code ChatGPT returns.
+5. Open **DevTools** → **Console**, paste the code and press **Enter**.
+6. A CSV with the collected profile URLs will download.
+7. Upload the CSV to Dhisana AI Smart List for enrichment or outreach.
+
+Tweak the prompt to target other selectors or elements and you can scrape nearly any page without paying for separate tools.


### PR DESCRIPTION
## Summary
- add a guide showing how to have ChatGPT generate javascript scrapers
- link the doc from the Scrape Content Hacks section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a4281ab8832d8d8d4a7e683fbb5e