### PR TITLE
Add JS extraction option to extract_from_webpage

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -328,6 +328,7 @@ UTILITY_PARAMETERS = {
             "label": "Actions to do on Website Load, first time. Like select filters",
         },
         {"name": "--page_actions", "label": "Actions to do When each page loads."},
+        {"name": "--run_js_on_page", "label": "JavaScript to run on each page"},
         {
             "name": "--parse_instructions",
             "label": "Custom instructions on how to extracts leads or company from the webpage that is loaded",
@@ -814,6 +815,7 @@ def run_utility():
                         parse_instructions=request.form.get("--parse_instructions", ""),
                         initial_actions=request.form.get("--initial_actions", ""),
                         page_actions=request.form.get("--page_actions", ""),
+                        run_js_on_page=request.form.get("--run_js_on_page", ""),
                         pagination_actions=request.form.get("--pagination_actions", ""),
                         max_pages=int(request.form.get("--max_pages") or 1),
                         mode=mode,

--- a/app/templates/run_utility.html
+++ b/app/templates/run_utility.html
@@ -308,9 +308,15 @@
         } else {
           div.className = 'mb-3';
           label.className = 'form-label';
-          input = document.createElement('input');
-          input.type = 'text';
-          input.className = 'form-control';
+          if (['--initial_actions','--page_actions','--pagination_actions','--parse_instructions','--run_js_on_page'].includes(p.name)) {
+            input = document.createElement('textarea');
+            input.className = 'form-control';
+            input.rows = 3;
+          } else {
+            input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'form-control';
+          }
         }
         input.name = p.name;
         if (util === 'linkedin_search_to_csv' && p.name === '--num') {

--- a/docs/utils_usage.md
+++ b/docs/utils_usage.md
@@ -401,8 +401,10 @@ detection. Provide the starting URL and use `--lead` or `--leads` to control how
 leads are returned. You can run custom
 JavaScript on the initial page load, on each page load and for pagination by
 supplying natural language instructions with `--initial_actions`,
-`--page_actions` and `--pagination_actions`. Parsing behaviour can be tweaked
-with `--parse_instructions`. Use `--max_pages` to limit how many pages are
+`--page_actions` and `--pagination_actions`. You can also run custom
+JavaScript directly on each page with `--run_js_on_page` and pass the result to
+the LLM instead of the raw HTML. Parsing behaviour can be tweaked with
+`--parse_instructions`. Use `--max_pages` to limit how many pages are
 navigated. The previous `--next_page_selector` and `--max_next_pages` options
 still work as a fallback.
 Pass `--show_ux` to launch a visible browser window and wait 30 seconds on each page.


### PR DESCRIPTION
## Summary
- add `--run_js_on_page` option for extract_from_webpage
- return `PageData` including html and optional JS output
- use JS output in prompts when provided
- expose new option in the web interface and docs
- render actions and JS parameters as textareas in UI
- test running JavaScript output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857bebe4bc0832db71ec7ca9a92a7ee